### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://ssw.visualstudio.com/84dc70dc-0c82-462e-a959-c8d08b403fdd/425b43a3-9ab5-4786-88c0-b4bb0c6ba57e/_apis/work/boardbadge/c923b86f-317e-463f-98b6-919948a4d45b)](https://ssw.visualstudio.com/84dc70dc-0c82-462e-a959-c8d08b403fdd/_boards/board/t/425b43a3-9ab5-4786-88c0-b4bb0c6ba57e/Microsoft.RequirementCategory)
 # SSW.Rules
 Secret ingredients to quality software


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#42130. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.