### PR TITLE
💄  Add word break to rule content

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -739,6 +739,7 @@ ol ol, ol li ol {
 .rule-content {
   color: black;
   font-size: 16px;
+  word-break: break-word;
 }
 
 b, strong {
@@ -752,6 +753,7 @@ b, strong {
     border-bottom: 1px solid rgb(175, 175, 175);
     padding-bottom: 3px;
     transition: color 0.25s ease;
+    line-height: 1.5rem;
     &:hover {
       @apply text-ssw-red;
       text-decoration: none;


### PR DESCRIPTION
https://github.com/SSWConsulting/SSW.Rules/issues/267

Long figure statements, links, paths and greyboxes were causing the rules page to overflow.