### PR TITLE
included <a> breadcrumb in the CSS

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -250,7 +250,7 @@ footer {
   }
 }
 
-.breadcrumb-content {
+.breadcrumb-content, a.breadcrumb-content {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   -webkit-text-decoration-style: solid;
@@ -261,7 +261,7 @@ footer {
   text-decoration-color: #AAA;
 }
 
-.breadcrumb-content:hover {
+.breadcrumb-content:hover, a.breadcrumb-content:hover {
   -webkit-text-decoration-color: #cc4141;
   text-decoration-color: #cc4141;
 }


### PR DESCRIPTION
So it underlines for SSW Rules too

<img width="362" alt="Screen Shot 2021-02-23 at 3 44 09 PM" src="https://user-images.githubusercontent.com/12601228/108923726-33ffcb00-75ee-11eb-91e5-0a9ccacf2793.png">
