### PR TITLE
Improving mobile view of email templates

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2451,3 +2451,24 @@ margin-bottom: 1em;
 .email-content h3 {
     margin-top: 1rem;
 }
+
+    /* Email Templates on MOBILES
+    -------------------------------------------------- */
+
+    @media all and (max-width:768px) {
+      .email-template table {
+        border-spacing: 5px;
+      }
+      .email-template table tr td {
+        display: table;
+        padding: 5px 9px;
+        width: 100%;
+      }
+      .email-template table tr td:first-child {
+        text-align: left;
+        padding: 5px 0;
+      }    
+      .email-content {
+        margin: 20px 10px;
+      }
+    }


### PR DESCRIPTION
Should change from:
<img width="423" alt="Screen Shot 2021-04-07 at 12 57 49 PM" src="https://user-images.githubusercontent.com/12601228/113926325-e192fc00-97a0-11eb-96dc-4810aaa3b7c5.png">

To:
<img width="413" alt="Screen Shot 2021-04-07 at 12 55 52 PM" src="https://user-images.githubusercontent.com/12601228/113926278-d2ac4980-97a0-11eb-87d1-5cfa4b830a8a.png">
