### PR TITLE
Add netlify cms index

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+</head>
+<body>
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
https://www.freecodecamp.org/news/how-to-build-a-blog-with-gatsby-and-netlify-cms/
https://www.netlifycms.org/docs/add-to-your-site/

Both these links say you should add an index.html even though it works locally without.
I am hoping this will make it work on staging