### PR TITLE
Revert "Make next and previous buttons always show up"

### DIFF
--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -37,15 +37,10 @@ const Rule = ({ data, location }) => {
   const capitalizeFirstLetter = (string) => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   };
-
+  const cat = location.state ? location.state.category : null;
   const linkRef = useRef();
   const rule = data.markdownRemark;
   const categories = data.categories.nodes;
-  const cat = location.state
-    ? location.state.category
-    : categories.length !== 0
-    ? categories[0].parent.name
-    : null;
   const { user, isAuthenticated, getIdTokenClaims } = useAuth0();
   const [hiddenCount, setHiddenCount] = useState(0);
 
@@ -205,7 +200,7 @@ const Rule = ({ data, location }) => {
                       if (relatedRule) {
                         return (
                           <>
-                            <li key={relatedRule.frontmatter.uri}>
+                            <li>
                               <section>
                                 <p>
                                   <Link


### PR DESCRIPTION
Reverts SSWConsulting/SSW.Rules#507 as it may be causing this bug.

This is only happening when you load a rule via the link, not through a category

![Screen Shot 2021-05-13 at 8 08 19 am](https://user-images.githubusercontent.com/38869720/118050329-638acc00-b3c2-11eb-9f6a-be2507c6eb1f.png)
