### PR TITLE
Revert "Fix large images"

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -493,6 +493,7 @@ pre {
   .ok-example {
     height: auto;
     min-width: 590px;
+    width: max-content;
   }
   
 }


### PR DESCRIPTION
Reverts SSWConsulting/SSW.Rules#518 as it may be causing this bug.

This is only happening when you load a rule via the link, not through a category

![](https://user-images.githubusercontent.com/38869720/118050329-638acc00-b3c2-11eb-9f6a-be2507c6eb1f.png)