### PR TITLE
Check if the related URI is in the redirects list

### DIFF
--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -87,6 +87,22 @@ const Rule = ({ data, location }) => {
     }
   };
 
+  const getRelatedRule = (relatedRuleUri) => {
+    var relatedRule = data.relatedRules.nodes.find(
+      (r) => r.frontmatter.uri === relatedRuleUri
+    );
+    !relatedRule &&
+      data.relatedRulesFromRedirects.nodes.forEach((r) => {
+        r.frontmatter.redirects &&
+          r.frontmatter.redirects.forEach((redirect) => {
+            if (redirect === relatedRuleUri) {
+              relatedRule = r;
+            }
+          });
+      });
+    return relatedRule;
+  };
+
   const SecretContent = (props) => {
     return (
       <>
@@ -194,21 +210,7 @@ const Rule = ({ data, location }) => {
               <ol>
                 {rule.frontmatter.related
                   ? rule.frontmatter.related.map((relatedRuleUri) => {
-                      const allRelatedRules = data.relatedRules.nodes.concat(
-                        data.relatedRulesFromRedirects.nodes
-                      );
-                      const relatedRule = allRelatedRules.find((r) => {
-                        if (r.frontmatter.uri === relatedRuleUri) {
-                          return r;
-                        } else {
-                          return (
-                            r.frontmatter.redirects &&
-                            r.frontmatter.redirects.find(
-                              (redirect) => redirect === relatedRuleUri
-                            )
-                          );
-                        }
-                      });
+                      const relatedRule = getRelatedRule(relatedRuleUri);
                       if (relatedRule) {
                         return (
                           <>

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -92,15 +92,15 @@ const Rule = ({ data, location }) => {
       (r) => r.frontmatter.uri === relatedRuleUri
     );
     if (!relatedRule) {
-      data.relatedRulesFromRedirects.nodes.forEach((r) => {
+      for (const r of data.relatedRulesFromRedirects.nodes) {
         if (r.frontmatter.redirects) {
-          r.frontmatter.redirects.forEach((redirect) => {
+          for (const redirect of r.frontmatter.redirects) {
             if (redirect === relatedRuleUri) {
-              relatedRule = r;
+              return r;
             }
-          });
+          }
         }
-      });
+      }
     }
     return relatedRule;
   };

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -201,14 +201,12 @@ const Rule = ({ data, location }) => {
                         if (r.frontmatter.uri === relatedRuleUri) {
                           return r;
                         } else {
-                          var relatedRuleFromRedirect;
-                          r.frontmatter.redirects &&
-                            r.frontmatter.redirects.find((redirect) => {
-                              if (redirect === relatedRuleUri) {
-                                relatedRuleFromRedirect = r;
-                              }
-                            });
-                          return relatedRuleFromRedirect;
+                          return (
+                            r.frontmatter.redirects &&
+                            r.frontmatter.redirects.find(
+                              (redirect) => redirect === relatedRuleUri
+                            )
+                          );
                         }
                       });
                       if (relatedRule) {

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -91,15 +91,17 @@ const Rule = ({ data, location }) => {
     var relatedRule = data.relatedRules.nodes.find(
       (r) => r.frontmatter.uri === relatedRuleUri
     );
-    !relatedRule &&
+    if (!relatedRule) {
       data.relatedRulesFromRedirects.nodes.forEach((r) => {
-        r.frontmatter.redirects &&
+        if (r.frontmatter.redirects) {
           r.frontmatter.redirects.forEach((redirect) => {
             if (redirect === relatedRuleUri) {
               relatedRule = r;
             }
           });
+        }
       });
+    }
     return relatedRule;
   };
 

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -194,9 +194,24 @@ const Rule = ({ data, location }) => {
               <ol>
                 {rule.frontmatter.related
                   ? rule.frontmatter.related.map((relatedRuleUri) => {
-                      const relatedRule = data.relatedRules.nodes.find(
-                        (r) => r.frontmatter.uri === relatedRuleUri
+                      const allRelatedRules = data.relatedRules.nodes.concat(
+                        data.relatedRulesFromRedirects.nodes
                       );
+                      const relatedRule = allRelatedRules.find((r) => {
+                        if (r.frontmatter.uri == relatedRuleUri) {
+                          return r;
+                        } else {
+                          var relatedRuleFromRedirect;
+                          if (r.frontmatter.redirects) {
+                            r.frontmatter.redirects.find((redirect) => {
+                              if (redirect === relatedRuleUri) {
+                                relatedRuleFromRedirect = r;
+                              }
+                            });
+                            return relatedRuleFromRedirect;
+                          }
+                        }
+                      });
                       if (relatedRule) {
                         return (
                           <>
@@ -408,6 +423,17 @@ export const query = graphql`
         frontmatter {
           title
           uri
+        }
+      }
+    }
+    relatedRulesFromRedirects: allMarkdownRemark(
+      filter: { frontmatter: { redirects: { in: $related } } }
+    ) {
+      nodes {
+        frontmatter {
+          title
+          uri
+          redirects
         }
       }
     }

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -198,18 +198,17 @@ const Rule = ({ data, location }) => {
                         data.relatedRulesFromRedirects.nodes
                       );
                       const relatedRule = allRelatedRules.find((r) => {
-                        if (r.frontmatter.uri == relatedRuleUri) {
+                        if (r.frontmatter.uri === relatedRuleUri) {
                           return r;
                         } else {
                           var relatedRuleFromRedirect;
-                          if (r.frontmatter.redirects) {
+                          r.frontmatter.redirects &&
                             r.frontmatter.redirects.find((redirect) => {
                               if (redirect === relatedRuleUri) {
                                 relatedRuleFromRedirect = r;
                               }
                             });
-                            return relatedRuleFromRedirect;
-                          }
+                          return relatedRuleFromRedirect;
                         }
                       });
                       if (relatedRule) {


### PR DESCRIPTION
issue #524

This change makes it check if the related URI on rule is one of the redirects on another rule.

If rule A has rule B listed as related and rule B changes its URI (and adds old URI to redirects list), the related section on rule A wouldn't work. 
Now, when rule A loads its related rules, it will check in the redirects list of rule B. 