### PR TITLE
🚸  Enable always_fork config option

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -4,6 +4,7 @@ backend:
   branch: staging
   open_authoring: true
   auth_endpoint: /api/auth
+  always_fork: true
 
 site_url: https://www.ssw.com.au/rules
 publish_mode: editorial_workflow


### PR DESCRIPTION
Issue #557

This config option will give all users the open authoring editorial workflow and force them to fork the repo instead of branching.
