### PR TITLE
UI - Fix youtube embed frame size

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -158,9 +158,6 @@ module.exports = {
           {
             resolve: 'gatsby-remark-embed-video',
             options: {
-              maxWidth: 800,
-              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
-              height: 400, // Optional: Overrides optional.ratio
               related: false, //Optional: Will remove related videos from the end of an embedded YouTube video.
               noIframeBorder: true, //Optional: Disable insertion of <style> border: 0
               urlOverrides: [


### PR DESCRIPTION
issue #565 

![2021-07-02_10-20-09](https://user-images.githubusercontent.com/38869720/124203013-194edd00-db1f-11eb-8f3b-2b8696d2e3cd.png)
**Figure: Fixed - the YouTube video frame is now the same size as the thumbnails**