### PR TITLE
Make links in archived reason clickable

### DIFF
--- a/src/cms/previewTemplate.js
+++ b/src/cms/previewTemplate.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { detectLinks } from '../helpers/convertUrlFromString';
 
 // customize markdown-it
 let options = {
@@ -80,7 +81,11 @@ var PreviewTemplate = ({ entry, getAsset }) => {
               </div>
               <div className="RuleArchivedReasonContainer px-4">
                 <span className="ReasonTitle">Archived Reason: </span>
-                {archivedReason}
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: detectLinks(archivedReason),
+                  }}
+                ></span>
               </div>
             </div>
           )}

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -27,15 +27,17 @@ const Breadcrumbs = (props) => {
           <img alt={'SSW Consulting'} src={Icon} className="w-4" />
         </a>
 
-        <span className="breadcrumb__separator">&gt;</span>
+        <span className="pl-1 breadcrumb__separator">&gt;</span>
 
-        <a className="breadcrumb-content px-1" href={siteUrl}>
-          SSW Rules
-        </a>
+        <Link ref={linkRef} to={siteUrl}>
+          <div className="breadcrumb-content px-1 hover:text-red-600">
+            SSW Rules
+          </div>
+        </Link>
 
-        <div className="px-1">
+        <span className="px-1">
           {props.isCategory || props.isRule || props.isArchived ? '>' : ''}
-        </div>
+        </span>
         {props.categories && (
           <div className="text-left ">{getCategories()}</div>
         )}
@@ -44,8 +46,9 @@ const Breadcrumbs = (props) => {
         ) : props.isCategory ? (
           <div className="px-1 text-gray-900">{props.categoryTitle}</div>
         ) : (
-          <div className="px-1 text-gray-900">
-            {props.isHomePage ? '' : '>'} {props.title}
+          <div className="text-gray-900">
+            <span className="px-1">{props.isHomePage ? '' : '>'}</span>
+            {props.title}
           </div>
         )}
       </div>

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -39,17 +39,17 @@ const Breadcrumbs = (props) => {
           {props.isCategory || props.isRule || props.isArchived ? '>' : ''}
         </span>
         {props.categories && (
-          <div className="text-left ">{getCategories()}</div>
+            <div className="text-left ">{getCategories()}</div>
         )}
         {props.isArchived ? (
-          <div className="px-1 text-gray-900">Archived</div>
+            <div className="px-1 text-gray-900">Archived</div>
         ) : props.isCategory ? (
-          <div className="px-1 text-gray-900">{props.categoryTitle}</div>
+            <div className="px-1 text-gray-900">{props.categoryTitle}</div>
         ) : (
-          <div className="text-gray-900">
-            <span className="px-1">{props.isHomePage ? '' : '>'}</span>
-            {props.title}
-          </div>
+            <div className="text-gray-900">
+              <span className="px-1">{props.isHomePage ? '' : '>'}</span>
+              {props.title}
+            </div>
         )}
       </div>
     </div>

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -39,17 +39,17 @@ const Breadcrumbs = (props) => {
           {props.isCategory || props.isRule || props.isArchived ? '>' : ''}
         </span>
         {props.categories && (
-            <div className="text-left ">{getCategories()}</div>
+          <div className="text-left ">{getCategories()}</div>
         )}
         {props.isArchived ? (
-            <div className="px-1 text-gray-900">Archived</div>
+          <div className="px-1 text-gray-900">Archived</div>
         ) : props.isCategory ? (
-            <div className="px-1 text-gray-900">{props.categoryTitle}</div>
+          <div className="px-1 text-gray-900">{props.categoryTitle}</div>
         ) : (
-            <div className="text-gray-900">
-              <span className="px-1">{props.isHomePage ? '' : '>'}</span>
-              {props.title}
-            </div>
+          <div className="text-gray-900">
+            <span className="px-1">{props.isHomePage ? '' : '>'}</span>
+            {props.title}
+          </div>
         )}
       </div>
     </div>

--- a/src/helpers/convertUrlFromString.js
+++ b/src/helpers/convertUrlFromString.js
@@ -1,0 +1,16 @@
+// make links clickable in archived reason
+const urlRegex =
+  /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
+
+export function detectLinks(text) {
+  const formatted = text.split(' ');
+  formatted.forEach(checkIfLink);
+  var newText = formatted.join(' ');
+  return newText;
+}
+
+function checkIfLink(word, index, array) {
+  if (word.match(urlRegex)) {
+    array[index] = `<a href="${word}">${word}</a>`;
+  }
+}

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -5,25 +5,31 @@ import { graphql, Link } from 'gatsby';
 import { format } from 'date-fns';
 import formatDistance from 'date-fns/formatDistance';
 import PropTypes from 'prop-types';
+
 import {
   faAngleDoubleLeft,
   faAngleDoubleRight,
   faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import GitHubIcon from '-!svg-react-loader!../images/github.svg';
-import Bookmark from '../components/bookmark/bookmark';
-import Breadcrumb from '../components/breadcrumb/breadcrumb';
-import Acknowledgements from '../components/acknowledgements/acknowledgements';
-import Reaction from '../components/reaction/reaction';
-import Comments from '../components/comments/comments';
 import { useAuth0 } from '@auth0/auth0-react';
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+
 import {
   GetOrganisations,
   GetSecretContent,
   GetGithubOrganisationName,
 } from '../services/apiService';
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+
+import { detectLinks } from '../helpers/convertUrlFromString';
+
+import Bookmark from '../components/bookmark/bookmark';
+import Breadcrumb from '../components/breadcrumb/breadcrumb';
+import Acknowledgements from '../components/acknowledgements/acknowledgements';
+import Reaction from '../components/reaction/reaction';
+import Comments from '../components/comments/comments';
 
 const appInsights = new ApplicationInsights({
   config: {
@@ -200,7 +206,11 @@ const Rule = ({ data, location }) => {
                 </div>
                 <div className="RuleArchivedReasonContainer px-4">
                   <span className="ReasonTitle">Archived Reason: </span>
-                  {rule.frontmatter.archivedreason}
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: detectLinks(rule.frontmatter.archivedreason),
+                    }}
+                  ></span>
                 </div>
               </div>
             )}


### PR DESCRIPTION
This fixes issue [#414](https://github.com/SSWConsulting/SSW.Rules/issues/414) and PBI [60653](https://dev.azure.com/ssw/SSW.Rules/_workitems/edit/60653).

Links included in the 'archived reason' field of a rule are now clickable.

![image](https://user-images.githubusercontent.com/40375803/124865473-1744bc80-dffe-11eb-83ae-e81e6cbb8b0c.png)
**Figure: Link is now a clickable \<a\> tag**