### PR TITLE
Add breathing room to header for mobile screens

### DIFF
--- a/lib/ssw.megamenu/menu/menu.module.css
+++ b/lib/ssw.megamenu/menu/menu.module.css
@@ -17,24 +17,34 @@
 .MegaMenu {
   font-family: Arial, sans-serif;
   font-weight: 400;
-}
-.MegaMenu {
   clear: both;
   height: 36px;
   line-height: 24px;
-  padding-left: 0;
+  width: 90%;
   z-index: 0;
   background: none repeat scroll 0 0 #414141;
   position: relative;
   z-index: 20;
+  margin:auto;
 }
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  .MegaMenu {
+    width: 95%
+  }
+}
+
+@media (min-width: 1280px) {
+  .MegaMenu {
+    width: 100%
+  }
+}
+
 .menuContent {
   display: inline-block;
   float: left;
-  width: 100%;
 }
 .menuMobile {
-  width: 100%;
   float: left;
   position: relative;
 }
@@ -81,6 +91,7 @@
   position: absolute;
   right: 0;
 }
+
 .menuSearch input.searchBox[type='text'] {
   background: url('https://ssw.com.au/ssw/include/pigeon/img/svg-sprite-sheet.svg') no-repeat scroll -2px -68px
     #9e9e9e;

--- a/src/cms/previewTemplate.js
+++ b/src/cms/previewTemplate.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { detectLinks } from '../helpers/convertUrlFromString';
 
 // customize markdown-it
 let options = {
@@ -80,7 +81,11 @@ var PreviewTemplate = ({ entry, getAsset }) => {
               </div>
               <div className="RuleArchivedReasonContainer px-4">
                 <span className="ReasonTitle">Archived Reason: </span>
-                {archivedReason}
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: detectLinks(archivedReason),
+                  }}
+                ></span>
               </div>
             </div>
           )}

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -27,15 +27,17 @@ const Breadcrumbs = (props) => {
           <img alt={'SSW Consulting'} src={Icon} className="w-4" />
         </a>
 
-        <span className="breadcrumb__separator">&gt;</span>
+        <span className="pl-1 breadcrumb__separator">&gt;</span>
 
-        <a className="breadcrumb-content px-1" href={siteUrl}>
-          SSW Rules
-        </a>
+        <Link ref={linkRef} to={siteUrl}>
+          <div className="breadcrumb-content px-1 hover:text-red-600">
+            SSW Rules
+          </div>
+        </Link>
 
-        <div className="px-1">
+        <span className="px-1">
           {props.isCategory || props.isRule || props.isArchived ? '>' : ''}
-        </div>
+        </span>
         {props.categories && (
           <div className="text-left ">{getCategories()}</div>
         )}
@@ -44,8 +46,9 @@ const Breadcrumbs = (props) => {
         ) : props.isCategory ? (
           <div className="px-1 text-gray-900">{props.categoryTitle}</div>
         ) : (
-          <div className="px-1 text-gray-900">
-            {props.isHomePage ? '' : '>'} {props.title}
+          <div className="text-gray-900">
+            <span className="px-1">{props.isHomePage ? '' : '>'}</span>
+            {props.title}
           </div>
         )}
       </div>

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -39,17 +39,17 @@ const Breadcrumbs = (props) => {
           {props.isCategory || props.isRule || props.isArchived ? '>' : ''}
         </span>
         {props.categories && (
-          <div className="text-left ">{getCategories()}</div>
+            <div className="text-left ">{getCategories()}</div>
         )}
         {props.isArchived ? (
-          <div className="px-1 text-gray-900">Archived</div>
+            <div className="px-1 text-gray-900">Archived</div>
         ) : props.isCategory ? (
-          <div className="px-1 text-gray-900">{props.categoryTitle}</div>
+            <div className="px-1 text-gray-900">{props.categoryTitle}</div>
         ) : (
-          <div className="text-gray-900">
-            <span className="px-1">{props.isHomePage ? '' : '>'}</span>
-            {props.title}
-          </div>
+            <div className="text-gray-900">
+              <span className="px-1">{props.isHomePage ? '' : '>'}</span>
+              {props.title}
+            </div>
         )}
       </div>
     </div>

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -39,17 +39,17 @@ const Breadcrumbs = (props) => {
           {props.isCategory || props.isRule || props.isArchived ? '>' : ''}
         </span>
         {props.categories && (
-            <div className="text-left ">{getCategories()}</div>
+          <div className="text-left ">{getCategories()}</div>
         )}
         {props.isArchived ? (
-            <div className="px-1 text-gray-900">Archived</div>
+          <div className="px-1 text-gray-900">Archived</div>
         ) : props.isCategory ? (
-            <div className="px-1 text-gray-900">{props.categoryTitle}</div>
+          <div className="px-1 text-gray-900">{props.categoryTitle}</div>
         ) : (
-            <div className="text-gray-900">
-              <span className="px-1">{props.isHomePage ? '' : '>'}</span>
-              {props.title}
-            </div>
+          <div className="text-gray-900">
+            <span className="px-1">{props.isHomePage ? '' : '>'}</span>
+            {props.title}
+          </div>
         )}
       </div>
     </div>

--- a/src/helpers/convertUrlFromString.js
+++ b/src/helpers/convertUrlFromString.js
@@ -1,0 +1,16 @@
+// make links clickable in archived reason
+const urlRegex =
+  /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
+
+export function detectLinks(text) {
+  const formatted = text.split(' ');
+  formatted.forEach(checkIfLink);
+  var newText = formatted.join(' ');
+  return newText;
+}
+
+function checkIfLink(word, index, array) {
+  if (word.match(urlRegex)) {
+    array[index] = `<a href="${word}">${word}</a>`;
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,30 @@ body {
   color:#333;
 }
 
+header {
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  header {
+    width: 95%;
+  }
+  .breadcrumb-container {
+    width: 95%;
+  }
+}
+
+@media (min-width: 1280px) {
+  header {
+    width: 100%;
+  }
+  .breadcrumb-container {
+    width: 100%;
+  }
+}
+
 .tagline {
   position: relative;
   top: 0;
@@ -191,6 +215,9 @@ footer {
 .breadcrumb-container{
   font-size: 0.8rem;
   margin-top: 1rem;
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .action-btn-container {

--- a/src/style.css
+++ b/src/style.css
@@ -215,7 +215,6 @@ footer {
 .breadcrumb-container{
   font-size: 0.8rem;
   margin-top: 1rem;
-  width: 90%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -5,25 +5,31 @@ import { graphql, Link } from 'gatsby';
 import { format } from 'date-fns';
 import formatDistance from 'date-fns/formatDistance';
 import PropTypes from 'prop-types';
+
 import {
   faAngleDoubleLeft,
   faAngleDoubleRight,
   faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import GitHubIcon from '-!svg-react-loader!../images/github.svg';
-import Bookmark from '../components/bookmark/bookmark';
-import Breadcrumb from '../components/breadcrumb/breadcrumb';
-import Acknowledgements from '../components/acknowledgements/acknowledgements';
-import Reaction from '../components/reaction/reaction';
-import Comments from '../components/comments/comments';
 import { useAuth0 } from '@auth0/auth0-react';
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+
 import {
   GetOrganisations,
   GetSecretContent,
   GetGithubOrganisationName,
 } from '../services/apiService';
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+
+import { detectLinks } from '../helpers/convertUrlFromString';
+
+import Bookmark from '../components/bookmark/bookmark';
+import Breadcrumb from '../components/breadcrumb/breadcrumb';
+import Acknowledgements from '../components/acknowledgements/acknowledgements';
+import Reaction from '../components/reaction/reaction';
+import Comments from '../components/comments/comments';
 
 const appInsights = new ApplicationInsights({
   config: {
@@ -200,7 +206,11 @@ const Rule = ({ data, location }) => {
                 </div>
                 <div className="RuleArchivedReasonContainer px-4">
                   <span className="ReasonTitle">Archived Reason: </span>
-                  {rule.frontmatter.archivedreason}
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: detectLinks(rule.frontmatter.archivedreason),
+                    }}
+                  ></span>
                 </div>
               </div>
             )}


### PR DESCRIPTION
Closes issue #384 and PBI [60420](https://dev.azure.com/ssw/SSW.Rules/_workitems/edit/60420)

Added styling for header elements (logo, buttons, navbar and breadcrumb) to create breathing room on the left and right for smaller screens.

![image](https://user-images.githubusercontent.com/40375803/124881377-9d6afe00-e012-11eb-9468-10d0bc067665.png)
**Figure: Mobile screen with breathing room**