### PR TITLE
💄 Add breathing room for mobile screens

### DIFF
--- a/lib/ssw.megamenu/menu/menu.module.css
+++ b/lib/ssw.megamenu/menu/menu.module.css
@@ -17,24 +17,34 @@
 .MegaMenu {
   font-family: Arial, sans-serif;
   font-weight: 400;
-}
-.MegaMenu {
   clear: both;
   height: 36px;
   line-height: 24px;
-  padding-left: 0;
+  width: 90%;
   z-index: 0;
   background: none repeat scroll 0 0 #414141;
   position: relative;
   z-index: 20;
+  margin: auto;
 }
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  .MegaMenu {
+    width: 95%
+  }
+}
+
+@media (min-width: 1280px) {
+  .MegaMenu {
+    width: 100%
+  }
+}
+
 .menuContent {
   display: inline-block;
   float: left;
-  width: 100%;
 }
 .menuMobile {
-  width: 100%;
   float: left;
   position: relative;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,30 @@ body {
   color:#333;
 }
 
+header {
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  header {
+    width: 95%;
+  }
+  .breadcrumb-container {
+    width: 95%;
+  }
+}
+
+@media (min-width: 1280px) {
+  header {
+    width: 100%;
+  }
+  .breadcrumb-container {
+    width: 100%;
+  }
+}
+
 .tagline {
   position: relative;
   top: 0;
@@ -191,6 +215,8 @@ footer {
 .breadcrumb-container{
   font-size: 0.8rem;
   margin-top: 1rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .action-btn-container {


### PR DESCRIPTION
Closes issue #384 and PBI [60420](https://dev.azure.com/ssw/SSW.Rules/_workitems/edit/60420)

Added styling for header elements (logo, buttons, navbar and breadcrumb) to create breathing room on the left and right for smaller screens.

![image](https://user-images.githubusercontent.com/40375803/125012592-ca202380-e0ad-11eb-85b0-08efd85778a7.png)
**Figure: Mobile screen with breathing room**