### PR TITLE
Updated breadcrumb responsive behaviour to align with menu above.

### DIFF
--- a/lib/ssw.megamenu/menu/menu.module.css
+++ b/lib/ssw.megamenu/menu/menu.module.css
@@ -17,24 +17,34 @@
 .MegaMenu {
   font-family: Arial, sans-serif;
   font-weight: 400;
-}
-.MegaMenu {
   clear: both;
   height: 36px;
   line-height: 24px;
-  padding-left: 0;
+  width: 90%;
   z-index: 0;
   background: none repeat scroll 0 0 #414141;
   position: relative;
   z-index: 20;
+  margin: auto;
 }
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  .MegaMenu {
+    width: 95%
+  }
+}
+
+@media (min-width: 1280px) {
+  .MegaMenu {
+    width: 100%
+  }
+}
+
 .menuContent {
   display: inline-block;
   float: left;
-  width: 100%;
 }
 .menuMobile {
-  width: 100%;
   float: left;
   position: relative;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,30 @@ body {
   color:#333;
 }
 
+header {
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  header {
+    width: 95%;
+  }
+  .breadcrumb-container {
+    width: 95%;
+  }
+}
+
+@media (min-width: 1280px) {
+  header {
+    width: 100%;
+  }
+  .breadcrumb-container {
+    width: 100%;
+  }
+}
+
 .tagline {
   position: relative;
   top: 0;
@@ -191,6 +215,8 @@ footer {
 .breadcrumb-container{
   font-size: 0.8rem;
   margin-top: 1rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .action-btn-container {

--- a/src/style.css
+++ b/src/style.css
@@ -38,24 +38,6 @@ header {
   margin-right: auto;
 }
 
-@media (min-width: 600px) and (max-width: 1279px) {
-  header {
-    width: 95%;
-  }
-  .breadcrumb-container {
-    width: 95%;
-  }
-}
-
-@media (min-width: 1280px) {
-  header {
-    width: 100%;
-  }
-  .breadcrumb-container {
-    width: 100%;
-  }
-}
-
 .tagline {
   position: relative;
   top: 0;
@@ -215,8 +197,29 @@ footer {
 .breadcrumb-container{
   font-size: 0.8rem;
   margin-top: 1rem;
+  width: 90%;
   margin-left: auto;
   margin-right: auto;
+}
+
+@media (min-width: 600px) and (max-width: 1279px) {
+  header {
+    width: 95%;
+  }
+  .breadcrumb-container {
+    width: 95%;
+  }
+}
+
+@media (min-width: 1280px) {
+  header {
+    width: 100%;
+  }
+  .breadcrumb-container {
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 .action-btn-container {


### PR DESCRIPTION
As per the conversation with @bradystroud @adamcogan, the breadcrumb was realigned to line up with the menu above it.

![image](https://user-images.githubusercontent.com/40375803/125232511-21c5c580-e320-11eb-89a0-736338802617.png)
**Figure: Breadcrumb icon now lines up with hamburger icon above.**