### PR TITLE
Added the CodeAuditor Box

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1255,12 +1255,28 @@ div.greybox {
   line-height: normal;
 }
 
-.rule-content .info, .rule-content .china {
+.rule-content .codeauditor:before {
+  content: "\f121 ";
+  font-family: FontAwesome;
+  font-size: 38px;
+  color: #cc4141;
+  float: left;
+  line-height: 38px;
+  margin-right: 1rem;
+  margin-top: 0.1rem;
+}
+
+.rule-content .info, .rule-content .china, .rule-content .codeauditor {
   display: block;
   padding: 10px;
   margin: 0 0 1rem;
   max-width: 100%;
+  min-height: 3.5rem;
   border: 1px solid #ccc;
+}
+
+.rule-content .codeauditor p {
+  padding-top: 0.6rem;
 }
 
 .rule-content .china:before {

--- a/src/style.css
+++ b/src/style.css
@@ -865,11 +865,6 @@ blockquote p:before {
   color: #ccc;
 }
 
-.rule-content p{
-  margin-top: 0;
-  margin-bottom: 1rem;
-}
-
 /* Category List
 -------------------------------------------------- */
 
@@ -1247,12 +1242,10 @@ div.greybox {
   content: "\f05a ";
   font-family: FontAwesome;
   font-size: 38px;
-  font-weight: normal;
-  text-decoration: inherit;
   color: #cc4141;
-  padding-right: 1rem;
   float: left;
   line-height: normal;
+  margin-right: 1rem;
 }
 
 .rule-content .codeauditor:before {
@@ -1261,9 +1254,8 @@ div.greybox {
   font-size: 38px;
   color: #cc4141;
   float: left;
-  line-height: 38px;
+  line-height: normal;
   margin-right: 1rem;
-  margin-top: 0.1rem;
 }
 
 .rule-content .info, .rule-content .china, .rule-content .codeauditor {
@@ -1271,17 +1263,22 @@ div.greybox {
   padding: 10px;
   margin: 0 0 1rem;
   max-width: 100%;
-  min-height: 3.5rem;
+  min-height: 3.6rem;
   border: 1px solid #ccc;
 }
 
+.rule-content .info p, .rule-content .china p {
+  padding-top: 0.35rem;
+}
+
 .rule-content .codeauditor p {
-  padding-top: 0.6rem;
+  padding-top: 0.45rem;
 }
 
 .rule-content .china:before {
   content: url(https://github.com/SSWConsulting/SSW.Rules/raw/main/static/assets/china-flag-icon.png);
-  padding-right: 1rem;
+  margin-right: 1rem;
+  padding-top: 0.15rem;
   float: left;
 }
 


### PR DESCRIPTION
Closes issue #417 and PBI 60656.

Added styling for a CodeAuditor box to be used with Markdown. Also restyled the Info and China boxes to have nicer padding and centring. 

![image](https://user-images.githubusercontent.com/40375803/125571941-9d9c65fd-4629-47eb-b81a-1da3c58c0c1c.png)
Figure: CodeAuditor box used in a test rule.