### PR TITLE
Add advanced edit button

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -21,7 +21,7 @@ const AnimatedContainer = posed.div({
     },
   },
 });
-const Header = ({ displayActions, ruleUri }) => {
+const Header = ({ displayActions }) => {
   return (
     <AnimatedContainer>
       <header>
@@ -41,36 +41,6 @@ const Header = ({ displayActions, ruleUri }) => {
             </p>
           </div>
           <div className="action-btn-container">
-            {displayActions ? (
-              <>
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  // href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${ruleUri}`}
-                  href={
-                    ruleUri.split('/')[2] == 'rule.md'
-                      ? `/rules/admin/#/collections/rule/entries/${
-                          ruleUri.split('/')[1]
-                        }/rule`
-                      : `https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${ruleUri}`
-                  }
-                  className="action-btn-link-underlined"
-                >
-                  <div className="edit-button-container">Edit</div>
-                </a>
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://rules.ssw.com.au/make-your-site-easy-to-maintain"
-                  className="action-btn-link-underlined"
-                >
-                  <div>Info</div>
-                  <InfoIcon aria-label="logo" className="action-btn-icon" />
-                </a>
-              </>
-            ) : (
-              <div></div>
-            )}
             <SignIn />
           </div>
         </div>

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -41,6 +41,19 @@ const Header = ({ displayActions }) => {
             </p>
           </div>
           <div className="action-btn-container">
+            {displayActions ? (
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://rules.ssw.com.au/make-your-site-easy-to-maintain"
+                className="action-btn-link-underlined"
+              >
+                <div>Info</div>
+                <InfoIcon aria-label="logo" className="action-btn-icon" />
+              </a>
+            ) : (
+              <div></div>
+            )}
             <SignIn />
           </div>
         </div>

--- a/src/style.css
+++ b/src/style.css
@@ -897,7 +897,6 @@ blockquote p:before {
   letter-spacing: normal;
   color: #ccc;
   margin: 0;
-  /* padding-left: 2rem; */
 }
 
 .rule-category .description {

--- a/src/style.css
+++ b/src/style.css
@@ -885,6 +885,7 @@ blockquote p:before {
   grid-template-columns: auto auto;
   padding: 1rem 1.5rem;
   background-color: #f5f5f5;
+  min-height: 90px;
 }
 
 .cat-title-grid-container h2.cat-title {
@@ -896,6 +897,7 @@ blockquote p:before {
   letter-spacing: normal;
   color: #ccc;
   margin: 0;
+  /* padding-left: 2rem; */
 }
 
 .rule-category .description {
@@ -1512,14 +1514,6 @@ div.greybox {
   margin-left: 0.5rem;
 }
 
-.category-tooltip {
-
-}
-
-.category-tooltip .tooltiptext {
-  left: 65%;
-}
-
 .tooltip, .react-tooltip, .disqus-tooltip, .info-tooltip, .forgot-username-tooltip {
   position: relative;
   display: inline-block;
@@ -1614,7 +1608,7 @@ div.greybox {
 }
 
 .category-tooltip {
-  bottom: 125%;
+  bottom: 105%;
 }
 
 .react-tooltip .tooltiptext {

--- a/src/style.css
+++ b/src/style.css
@@ -1512,12 +1512,12 @@ div.greybox {
   margin-left: 0.5rem;
 }
 
-.category-tooltip .tooltiptext {
-  left: 65%;
+.category-tooltip {
+
 }
 
-.category-tooltip .category-icon {
-  margin-bottom: 24px;
+.category-tooltip .tooltiptext {
+  left: 65%;
 }
 
 .tooltip, .react-tooltip, .disqus-tooltip, .info-tooltip, .forgot-username-tooltip {
@@ -1607,10 +1607,14 @@ div.greybox {
   transition: opacity 0.2s;
 }
 
-.tooltip .tooltiptext :not(.category-icon) {
+.tooltip .tooltiptext {
   left: 65%;
   margin-left: -60px;
   margin-bottom: 0;
+}
+
+.category-tooltip {
+  bottom: 125%;
 }
 
 .react-tooltip .tooltiptext {

--- a/src/style.css
+++ b/src/style.css
@@ -896,7 +896,6 @@ blockquote p:before {
   letter-spacing: normal;
   color: #ccc;
   margin: 0;
-  justify-self: end;
 }
 
 .rule-category .description {
@@ -972,7 +971,7 @@ blockquote p:before {
   color: #cc4141;
 }
 
-.rule-content a[href*="//"]:not([href*="ssw.com.au"], .info-btn-container):after {
+.rule-content a[href*="//"]:not([href*="ssw.com.au"], .info-btn-container, .tooltip-button):after {
     content: "\f08b ";
     font-family: FontAwesome;
     opacity: .5;
@@ -1508,9 +1507,71 @@ div.greybox {
   opacity: 0.5;
 }
 
+.category-icon {
+  margin-top: 0;
+  margin-left: 0.5rem;
+}
+
+.category-tooltip .tooltiptext {
+  left: 65%;
+}
+
+.category-tooltip .category-icon {
+  margin-bottom: 24px;
+}
+
 .tooltip, .react-tooltip, .disqus-tooltip, .info-tooltip, .forgot-username-tooltip {
   position: relative;
   display: inline-block;
+}
+
+.tooltip-button {
+  width: 60px;
+}
+
+.tooltip-button a:after {
+  display:none;
+}
+
+.bookmark-icon .tooltip-button {
+  margin-top: 1.6rem;
+}
+
+.tooltip-button svg {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tooltip-button svg:hover {
+  font-size: 2.2em;
+}
+
+.tooltip-icon {
+  color:rgb(204, 204, 204);
+  height: 2rem;
+  margin-top: 38px;
+  margin-right: 18px;
+}
+
+.tooltip-icon:hover {
+  height: 2.2rem;
+  transition: height 0.25s ;
+}
+
+.tooltip-button .tooltiptext {
+  margin-left: -58px;
+}
+
+@media screen and (max-width: 640px) {
+  .rule-buttons button:first-child 
+  {
+    margin-top: 1rem;
+  }
+
+  .tooltip-button svg {
+    margin-top: 0.75rem;
+  }
 }
 
 .disqus-tooltip {
@@ -1546,7 +1607,7 @@ div.greybox {
   transition: opacity 0.2s;
 }
 
-.tooltip .tooltiptext {
+.tooltip .tooltiptext :not(.category-icon) {
   left: 65%;
   margin-left: -60px;
   margin-bottom: 0;

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -8,7 +8,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 export default function Category({ data }) {
-  console.log(data);
   const linkRef = useRef();
   const category = data.markdownRemark;
 

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -42,10 +42,10 @@ export default function Category({ data }) {
               <h2 className="cat-title">
                 {category.frontmatter.title}
                 <span className="rule-count">
-                  {'   '} {rules.length} {rules.length > 1 ? 'Rules' : 'Rule'}
+                  {' - '} {rules.length} {rules.length > 1 ? 'Rules' : 'Rule'}
                 </span>
               </h2>
-              <button className="tooltip justify-self-end">
+              <button className="tooltip justify-self-end mt-1">
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
@@ -58,7 +58,9 @@ export default function Category({ data }) {
                     className="category-icon bookmark-icon"
                   />
                 </a>
-                <span className="tooltiptext">Edit in GitHub</span>
+                <span className="category-tooltip tooltiptext">
+                  Edit in GitHub
+                </span>
               </button>
             </div>
 

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import MD from 'gatsby-custom-md';
 import GreyBox from '../components/greybox/greybox';
 import Breadcrumb from '../components/breadcrumb/breadcrumb';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 export default function Category({ data }) {
+  console.log(data);
   const linkRef = useRef();
   const category = data.markdownRemark;
 
@@ -36,10 +39,29 @@ export default function Category({ data }) {
         <div className="rule-category rounded">
           <section className="mb-20 pb-2 rounded">
             <div className="cat-title-grid-container">
-              <h2 className="cat-title">{category.frontmatter.title}</h2>
-              <h2 className="rule-count">
-                {rules.length} {rules.length > 1 ? 'Rules' : 'Rule'}
+              <h2 className="cat-title">
+                {category.frontmatter.title}
+                <span className="rule-count">
+                  {'   '} {rules.length} {rules.length > 1 ? 'Rules' : 'Rule'}
+                </span>
               </h2>
+              <button className="tooltip tooltip-button justify-self-end">
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${category.parent.relativePath}`}
+                  className="category-tooltip tooltip tooltip-button"
+                >
+                  <FontAwesomeIcon
+                    icon={faGithub}
+                    size="2x"
+                    className="category-icon bookmark-icon"
+                  />
+                  <span className="category-icon tooltiptext">
+                    Edit in GitHub
+                  </span>
+                </a>
+              </button>
             </div>
 
             <div className="rule-category-top pt-5 py-4 px-6">
@@ -171,6 +193,7 @@ export const query = graphql`
       frontmatter {
         title
         index
+        uri
       }
       parent {
         ... on File {

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -45,22 +45,20 @@ export default function Category({ data }) {
                   {'   '} {rules.length} {rules.length > 1 ? 'Rules' : 'Rule'}
                 </span>
               </h2>
-              <button className="tooltip tooltip-button justify-self-end">
+              <button className="tooltip justify-self-end">
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
                   href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${category.parent.relativePath}`}
-                  className="category-tooltip tooltip tooltip-button"
+                  className="tooltip tooltip-button"
                 >
                   <FontAwesomeIcon
                     icon={faGithub}
                     size="2x"
                     className="category-icon bookmark-icon"
                   />
-                  <span className="category-icon tooltiptext">
-                    Edit in GitHub
-                  </span>
                 </a>
+                <span className="tooltiptext">Edit in GitHub</span>
               </button>
             </div>
 

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -19,6 +19,8 @@ import Breadcrumb from '../components/breadcrumb/breadcrumb';
 import Acknowledgements from '../components/acknowledgements/acknowledgements';
 import Comments from '../components/comments/comments';
 import Reaction from '../components/reaction/reaction';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 import { useAuth0 } from '@auth0/auth0-react';
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
@@ -93,15 +95,15 @@ const Rule = ({ data, location }) => {
     }
   };
 
-  const getRelatedRule = (relatedRuleUri) => {
+  const getRelatedRule = (relateduri) => {
     var relatedRule = data.relatedRules.nodes.find(
-      (r) => r.frontmatter.uri === relatedRuleUri
+      (r) => r.frontmatter.uri === relateduri
     );
     if (!relatedRule) {
       for (const r of data.relatedRulesFromRedirects.nodes) {
         if (r.frontmatter.redirects) {
           for (const redirect of r.frontmatter.redirects) {
-            if (redirect === relatedRuleUri) {
+            if (redirect === relateduri) {
               return r;
             }
           }
@@ -167,9 +169,47 @@ const Rule = ({ data, location }) => {
       />
       <div className="rule-single rounded">
         <section className="rule-content">
-          <div className="rule-header-container">
+          <div className="rule-header-container justify-between">
             <h1>{rule.frontmatter.title}</h1>
-            <Bookmark ruleId={rule.frontmatter.guid} />
+            <div className="rule-buttons flex flex-col sm:flex-row">
+              <Bookmark ruleId={rule.frontmatter.guid} />
+              <button className="tooltip tooltip-button">
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={
+                    rule.frontmatter.uri.split('/')[2] == 'rule.md'
+                      ? `/rules/admin/#/collections/rule/entries/${
+                          rule.frontmatter.uri.split('/')[1]
+                        }/rule`
+                      : `https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${rule.frontmatter.uri}`
+                  }
+                  className="tooltip tooltip-button"
+                >
+                  <FontAwesomeIcon
+                    icon={faPencilAlt}
+                    size="2x"
+                    className="bookmark-icon"
+                  />
+                  <span className="tooltiptext">Edit</span>
+                </a>
+              </button>
+              <button className="tooltip tooltip-button">
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${rule.frontmatter.uri}`}
+                  className="tooltip tooltip-button"
+                >
+                  <FontAwesomeIcon
+                    icon={faGithub}
+                    size="2x"
+                    className="bookmark-icon"
+                  />
+                  <span className="tooltiptext">Edit in GitHub</span>
+                </a>
+              </button>
+            </div>
           </div>
           {data.history && data.history.nodes[0] && (
             <small className="history">
@@ -221,8 +261,8 @@ const Rule = ({ data, location }) => {
               <h2>Related Rules</h2>
               <ol>
                 {rule.frontmatter.related
-                  ? rule.frontmatter.related.map((relatedRuleUri) => {
-                      const relatedRule = getRelatedRule(relatedRuleUri);
+                  ? rule.frontmatter.related.map((relateduri) => {
+                      const relatedRule = getRelatedRule(relateduri);
                       if (relatedRule) {
                         return (
                           <>

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -97,7 +97,7 @@ const Rule = ({ data, location }) => {
 
   const getRelatedRule = (relatedUri) => {
     var relatedRule = data.relatedRules.nodes.find(
-      (r) => r.frontmatter.uri === relateduri
+      (r) => r.frontmatter.uri === relatedUri
     );
     if (!relatedRule) {
       for (const r of data.relatedRulesFromRedirects.nodes) {

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -261,8 +261,8 @@ const Rule = ({ data, location }) => {
               <h2>Related Rules</h2>
               <ol>
                 {rule.frontmatter.related
-                  ? rule.frontmatter.related.map((relateduri) => {
-                      const relatedRule = getRelatedRule(relateduri);
+                  ? rule.frontmatter.related.map((relatedUri) => {
+                      const relatedRule = getRelatedRule(relatedUri);
                       if (relatedRule) {
                         return (
                           <>

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -103,7 +103,7 @@ const Rule = ({ data, location }) => {
       for (const r of data.relatedRulesFromRedirects.nodes) {
         if (r.frontmatter.redirects) {
           for (const redirect of r.frontmatter.redirects) {
-            if (redirect === relateduri) {
+            if (redirect === relatedUri) {
               return r;
             }
           }

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -42,7 +42,6 @@ const appInsights = new ApplicationInsights({
 appInsights.loadAppInsights();
 
 const Rule = ({ data, location }) => {
-  console.log(data);
   const capitalizeFirstLetter = (string) => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   };

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -95,7 +95,7 @@ const Rule = ({ data, location }) => {
     }
   };
 
-  const getRelatedRule = (relateduri) => {
+  const getRelatedRule = (relatedUri) => {
     var relatedRule = data.relatedRules.nodes.find(
       (r) => r.frontmatter.uri === relateduri
     );

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -42,6 +42,7 @@ const appInsights = new ApplicationInsights({
 appInsights.loadAppInsights();
 
 const Rule = ({ data, location }) => {
+  console.log(data);
   const capitalizeFirstLetter = (string) => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   };
@@ -173,7 +174,7 @@ const Rule = ({ data, location }) => {
             <h1>{rule.frontmatter.title}</h1>
             <div className="rule-buttons flex flex-col sm:flex-row">
               <Bookmark ruleId={rule.frontmatter.guid} />
-              <button className="tooltip tooltip-button">
+              <button className="tooltip">
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
@@ -191,14 +192,14 @@ const Rule = ({ data, location }) => {
                     size="2x"
                     className="bookmark-icon"
                   />
-                  <span className="tooltiptext">Edit</span>
                 </a>
+                <span className="tooltiptext">Edit</span>
               </button>
-              <button className="tooltip tooltip-button">
+              <button className="tooltip">
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${rule.frontmatter.uri}`}
+                  href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/${rule.parent.relativePath}`}
                   className="tooltip tooltip-button"
                 >
                   <FontAwesomeIcon
@@ -206,8 +207,8 @@ const Rule = ({ data, location }) => {
                     size="2x"
                     className="bookmark-icon"
                   />
-                  <span className="tooltiptext">Edit in GitHub</span>
                 </a>
+                <span className="tooltiptext">Edit in GitHub</span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
Closes issue #572  and PBI 62186.

Added an 'Edit in GitHub' button to the rule template, and changed the existing UI to suit.

![image](https://user-images.githubusercontent.com/40375803/126935594-05d60ba1-3893-4145-ba7d-d7280d26d165.png)
Figure: Edit button moved in a category.

![image](https://user-images.githubusercontent.com/40375803/126935717-93e71139-1f5f-4182-b28c-d20e55d946b9.png)
Figure: Edit button moved in a rule and new button added.