### PR TITLE
63218 help button

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -21,13 +21,21 @@ const Footer = () => {
       <div className="py-2 text-center bg-grey-translucent text-sm">
         <section className="main-container">
           We <FontAwesomeIcon icon={faHeart} className="text-ssw-red" /> open
-          source. This page is on{' '}
+          source. Powered by{' '}
           <a
-            className="action-button-label"
+            className="action-button-label footer-greybar-link"
             href="https://github.com/SSWConsulting/SSW.Rules"
           >
             GitHub <FontAwesomeIcon icon={faGithub} />
+          </a>{' '}
+          and made{' '}
+          <a
+            className="action-button-label footer-greybar-link"
+            href="https://www.ssw.com.au/rules/make-your-site-easy-to-maintain"
+          >
+            easy to maintain
           </a>
+          .
         </section>
       </div>
       <footer className="bg-black py-6 md:py-4 lg:py-2">

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import posed from 'react-pose';
 import SSWLogo from '-!svg-react-loader!../../images/SSWLogo.svg';
-import InfoIcon from '-!svg-react-loader!../../images/info.svg';
 import SignIn from '../signin/signin';
 import { parentSiteUrl } from '../../../site-config';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import {
+  faPlusCircle,
+  faQuestionCircle,
+} from '@fortawesome/free-solid-svg-icons';
 
 // Example of a component-specific page transition
 const AnimatedContainer = posed.div({
@@ -58,11 +60,11 @@ const Header = ({ displayActions }) => {
             <a
               target="_blank"
               rel="noopener noreferrer"
-              href="https://rules.ssw.com.au/make-your-site-easy-to-maintain"
+              href="https://github.com/SSWConsulting/SSW.Rules.Content/wiki"
               className="action-btn-link-underlined"
             >
-              <div>Info</div>
-              <InfoIcon aria-label="logo" className="action-btn-icon" />
+              <div>Help</div>
+              <FontAwesomeIcon icon={faQuestionCircle} className="ml-1" />
             </a>
             <SignIn />
           </div>

--- a/src/style.css
+++ b/src/style.css
@@ -102,6 +102,10 @@ a.footer-link,a.footer-link:visited  {
   }
 }
 
+a.footer-greybar-link, a.footer-greybar-link:hover {
+  text-decoration: underline;
+}
+
 
 .navigation-category a{
   @apply text-ssw-red !important;


### PR DESCRIPTION
Closes issue #620 and PBI 63218.

Added a 'help' button to the header of SSW Rules and moved info button to footer as a link.

![image](https://user-images.githubusercontent.com/40375803/128286873-da6c7123-845b-4e72-8772-2c9cf16eb1b0.png)
**Figure: Help button in the header where Info button was.**

![image](https://user-images.githubusercontent.com/40375803/128286975-13c56f9d-11e8-40ef-a0c6-3c0ccb3205e5.png)
**Figure: Info button link is now in footer.**