### PR TITLE
Make heading links red

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -85,8 +85,8 @@ h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
 }
 
 h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover {
-  color: #aaa;
-  text-decoration-color: #aaa;
+  color: #222;
+  text-decoration-color: #222;
 }
 
 a, a:visited {

--- a/src/style.css
+++ b/src/style.css
@@ -77,6 +77,18 @@ h4 {
   @apply mb-2;
 }
 
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+  color: #cc4141;
+  text-decoration-color: #cc4141;
+  -webkit-text-decoration-thickness: 1px;
+  text-decoration-thickness: 1px;
+}
+
+h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover {
+  color: #aaa;
+  text-decoration-color: #aaa;
+}
+
 a, a:visited {
   &:not(.unstyled):not(h1 a):not(h2 a):not(h3 a):not(h4 a):not(h5 a):not(h6 a) {
     color: #222;
@@ -88,10 +100,6 @@ a, a:visited {
       text-decoration: none;
     } 
   } 
-}
-
-h4 a, h5 a, h6 a {
-  @apply text-ssw-red;
 }
 
 a.footer-link,a.footer-link:visited  {
@@ -752,7 +760,7 @@ b, strong {
 }
 
 .rule-content a, .rule-category-top a {
-  &:not(.unstyled):not(.action-btn-link):not(.action-btn-link-underlined):not(.info-btn-container) {
+  &:not(.unstyled):not(.action-btn-link):not(.action-btn-link-underlined):not(.info-btn-container):not(h1 a):not(h2 a):not(h3 a):not(h4 a):not(h5 a):not(h6 a) {
     transition: color 0.25s ease;
     line-height: 1.5rem;
     -webkit-text-decoration: underline;
@@ -1048,7 +1056,7 @@ blockquote p:before {
 
 .rule-content a,
 .rule-category a {
-  text-decoration:underline;
+  text-decoration-line: underline;
   transition: color 0.25s ease;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -78,7 +78,7 @@ h4 {
 }
 
 a, a:visited {
-  &:not(.unstyled) {
+  &:not(.unstyled):not(h1 a):not(h2 a):not(h3 a):not(h4 a):not(h5 a):not(h6 a) {
     color: #222;
     text-decoration: none;
     transition: color 0.25s ease;
@@ -88,6 +88,10 @@ a, a:visited {
       text-decoration: none;
     } 
   } 
+}
+
+h4 a, h5 a, h6 a {
+  @apply text-ssw-red;
 }
 
 a.footer-link,a.footer-link:visited  {


### PR DESCRIPTION
Closes issue #627 and PBI 63292

Make links within headings red instead of black.

![image](https://user-images.githubusercontent.com/40375803/128959214-f1b09d4b-a15c-43e3-947e-3be80a5e2107.png)
**Figure: Headings now red even though they are links**