### PR TITLE
Add instructions to new rule default text

### DIFF
--- a/src/cms/config.js
+++ b/src/cms/config.js
@@ -50,8 +50,15 @@ var configJson = {
             name: 'body',
             label: 'Body',
             widget: 'markdown',
-            default:
-              'Markdown shown in the blurb.<br><!--endintro--><br>Markdown not shown in the blurb',
+            default: `Instructions for creating rules can be found at [How to Create Rules](https://github.com/SSWConsulting/SSW.Rules.Content/wiki/How-to-Create-Rules). Follow the steps below and replace the text in this box with your own content.
+            
+1. Place your intro here. This will show in the blurb.
+            
+<!--endintro-->
+
+2. Place your content here. Markdown is your friend. See this [example rule](https://www.ssw.com.au/rules/rule) for all the things you can do with Rules.
+3. Submit your rule for review.
+4. Add your rule to a category. See [How to Add and Edit Categories and Top Categories](https://github.com/SSWConsulting/SSW.Rules.Content/wiki/How-to-Add-and-Edit-Categories-and-Top-Categories).`,
           },
           {
             name: 'authors',


### PR DESCRIPTION
Added text to the default value of the Body field in the editor to provide users with some instructions when creating a new rule.