### PR TITLE
Remove validation from redirect URI

### DIFF
--- a/src/cms/config.js
+++ b/src/cms/config.js
@@ -86,10 +86,6 @@ var configJson = {
             field: {
               name: 'redirectUri',
               label: 'Redirect uri',
-              pattern: [
-                '^[a-zA-Z0-9_-]*$',
-                'Must only contain alphanumeric or the "-" and "_" characters',
-              ],
             },
           },
           {


### PR DESCRIPTION
Closes issue #607 and PBI 62890

Removes validation from the redirect URI to allow special characters to be used. This allows old URIs with parentheses, apostrophes and other characters to be stored for redirection, but doesn't allow new URIs to feature these characters.

![image](https://user-images.githubusercontent.com/40375803/129123545-0304de28-2e0e-4d80-ac2a-7904a7601197.png)
**Figure: Saved redirect URI with special characters**