### PR TITLE
 Add editing buttons to rules on category page

### DIFF
--- a/src/components/bookmark/bookmark.js
+++ b/src/components/bookmark/bookmark.js
@@ -83,12 +83,12 @@ const Bookmark = (props) => {
   return (
     <>
       {bookmarked ? (
-        <button onClick={onClick} className="tooltip">
+        <button onClick={onClick} className="tooltip category-bookmark">
           <BookmarkIcon className="bookmark-icon-pressed" />
           <span className="tooltiptext">Remove Bookmark</span>
         </button>
       ) : (
-        <button onClick={onClick} className="tooltip">
+        <button onClick={onClick} className="tooltip category-bookmark">
           <BookmarkIcon className="text-ssw-red bookmark-icon" />
           <span className="tooltiptext">Add Bookmark</span>
         </button>

--- a/src/style.css
+++ b/src/style.css
@@ -1013,7 +1013,6 @@ blockquote p:before {
 
 .rule-content-title h2 {
   padding: .5rem .75rem;
-  background: #f5f5f5;
   border-left: 2px solid #cc4141; 
 }
 
@@ -1575,6 +1574,10 @@ div.greybox {
   display: flex;
 }
 
+.rule-content-title .rule-header-container {
+  background-color: #f5f5f5
+}
+
 .edit-button-container::after {
   font-family: FontAwesome;
   content: '\f040';
@@ -1601,6 +1604,10 @@ div.greybox {
   color: #cc4141;
 }
 
+.category .tooltip .bookmark-icon, .category .tooltip .bookmark-icon-pressed {
+  margin-bottom: 0.5rem;
+}
+
 .header-icon {
   color: #414141;
 }
@@ -1612,6 +1619,10 @@ div.greybox {
 .category-icon {
   margin-top: 0;
   margin-left: 0.5rem;
+}
+
+.category-bookmark {
+  padding-bottom: 0.5rem;
 }
 
 .tooltip, .react-tooltip, .disqus-tooltip, .info-tooltip, .forgot-username-tooltip {

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -6,6 +6,8 @@ import GreyBox from '../components/greybox/greybox';
 import Breadcrumb from '../components/breadcrumb/breadcrumb';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import Bookmark from '../components/bookmark/bookmark';
+import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 
 export default function Category({ data }) {
   const linkRef = useRef();
@@ -131,15 +133,55 @@ export default function Category({ data }) {
                     <>
                       <li>
                         <section className="rule-content-title pl-2">
-                          <h2>
-                            <Link
-                              ref={linkRef}
-                              to={`/${rule.frontmatter.uri}`}
-                              state={{ category: category.parent.name }}
-                            >
-                              {rule.frontmatter.title}
-                            </Link>
-                          </h2>
+                          <div className="rule-header-container justify-between">
+                            <h2>
+                              <Link
+                                ref={linkRef}
+                                to={`/${rule.frontmatter.uri}`}
+                                state={{ category: category.parent.name }}
+                              >
+                                {rule.frontmatter.title}
+                              </Link>
+                            </h2>
+                            <div className="rule-buttons flex flex-col sm:flex-row category">
+                              <Bookmark
+                                ruleId={rule.frontmatter.guid}
+                                className="category-bookmark"
+                              />
+                              <button className="tooltip">
+                                <a
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  href={`/rules/admin/#/collections/rule/entries/${rule.frontmatter.uri}/rule`}
+                                  className="tooltip tooltip-button"
+                                >
+                                  <FontAwesomeIcon
+                                    icon={faPencilAlt}
+                                    size="lg"
+                                    className="text-ssw-red bookmark-icon"
+                                  />
+                                </a>
+                                <span className="tooltiptext">Edit</span>
+                              </button>
+                              <button className="tooltip">
+                                <a
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  href={`https://github.com/SSWConsulting/SSW.Rules.Content/tree/${process.env.CONTENT_BRANCH}/rules/${rule.frontmatter.uri}/rule.md`}
+                                  className="tooltip tooltip-button"
+                                >
+                                  <FontAwesomeIcon
+                                    icon={faGithub}
+                                    size="lg"
+                                    className="text-ssw-red bookmark-icon"
+                                  />
+                                </a>
+                                <span className="tooltiptext">
+                                  Edit in GitHub
+                                </span>
+                              </button>
+                            </div>
+                          </div>
                         </section>
 
                         <section


### PR DESCRIPTION
Closes #241 and PBI 59813

Added 'bookmark', 'edit' and 'edit in GitHub' buttons next to rules on the category page.

![image](https://user-images.githubusercontent.com/40375803/130392351-e9ec9825-9c34-4eec-994e-2b3ffb582ba8.png)
**Figure: Buttons added to header of a rule on category page**