### PR TITLE
Fix - Make heading links red

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1582,14 +1582,11 @@ div.greybox {
   margin-bottom: 0.5rem;
 }
 
-<<<<<<< Updated upstream
-=======
 .rule-content-title .rule-header-container {
   background-color: #f5f5f5;
   height: 52px;
 }
 
->>>>>>> Stashed changes
 .edit-button-container::after {
   font-family: FontAwesome;
   content: '\f040';

--- a/src/style.css
+++ b/src/style.css
@@ -77,20 +77,20 @@ h4 {
   @apply mb-2;
 }
 
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+.rule-content h1 a, .rule-content h2 a, .rule-content h3 a, .rule-content h4 a, .rule-content h5 a, .rule-content h6 a {
   color: #cc4141;
   text-decoration-color: #cc4141;
   -webkit-text-decoration-thickness: 1px;
   text-decoration-thickness: 1px;
 }
 
-h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover {
+.rule-content h1 a:hover, .rule-content h2 a:hover, .rule-content h3 a:hover, .rule-content h4 a:hover, .rule-content h5 a:hover, .rule-content h6 a:hover {
   color: #222;
   text-decoration-color: #222;
 }
 
 a, a:visited {
-  &:not(.unstyled):not(h1 a):not(h2 a):not(h3 a):not(h4 a):not(h5 a):not(h6 a) {
+  &:not(.unstyled):not(.rule-content h1 a):not(.rule-content h2 a):not(.rule-content h3 a):not(.rule-content h4 a):not(.rule-content h5 a):not(.rule-content h6 a) {
     color: #222;
     text-decoration: none;
     transition: color 0.25s ease;
@@ -1013,8 +1013,13 @@ blockquote p:before {
 
 .rule-content-title h2 {
   padding: .5rem .75rem;
-  background: #f5f5f5;
+  background-color: #f5f5f5;
+  margin: 0;
   border-left: 2px solid #cc4141; 
+}
+
+.rule-header-container .bookmark-icon, .rule-header-container .bookmark-icon-pressed {
+  margin-top: 0.75rem;
 }
 
 .rule-category-top p {
@@ -1573,8 +1578,18 @@ div.greybox {
 
 .rule-header-container {
   display: flex;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
+<<<<<<< Updated upstream
+=======
+.rule-content-title .rule-header-container {
+  background-color: #f5f5f5;
+  height: 52px;
+}
+
+>>>>>>> Stashed changes
 .edit-button-container::after {
   font-family: FontAwesome;
   content: '\f040';

--- a/src/style.css
+++ b/src/style.css
@@ -1014,12 +1014,7 @@ blockquote p:before {
 .rule-content-title h2 {
   padding: .5rem .75rem;
   background-color: #f5f5f5;
-  margin: 0;
   border-left: 2px solid #cc4141; 
-}
-
-.rule-header-container .bookmark-icon, .rule-header-container .bookmark-icon-pressed {
-  margin-top: 0.75rem;
 }
 
 .rule-category-top p {
@@ -1578,13 +1573,6 @@ div.greybox {
 
 .rule-header-container {
   display: flex;
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.rule-content-title .rule-header-container {
-  background-color: #f5f5f5;
-  height: 52px;
 }
 
 .edit-button-container::after {


### PR DESCRIPTION
The original change in #630 that resolved #627 was incorrectly scoped and affected rule headings as well as headings within the content itself.

![image](https://user-images.githubusercontent.com/40375803/130397510-155f24a8-5649-451f-8ad3-2c604a20a03e.png)
**Figure: Rule headers changed to red accidentally**

This has been amended in this PR.

![image](https://user-images.githubusercontent.com/40375803/130397698-c8345395-5f76-490c-b001-4d5110cc02a4.png)
**Figure: Rule headers now original black colour**