### PR TITLE
Fixing links

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -89,7 +89,7 @@ h4 {
   text-decoration-color: #222;
 }
 
-a, a:visited {
+.rule-content a, .rule-content a:visited, .rule-header-container a, .rule-header-container a:visited {
   &:not(.unstyled):not(.rule-content h1 a):not(.rule-content h2 a):not(.rule-content h3 a):not(.rule-content h4 a):not(.rule-content h5 a):not(.rule-content h6 a) {
     color: #222;
     text-decoration: none;

--- a/src/style.css
+++ b/src/style.css
@@ -1017,8 +1017,12 @@ blockquote p:before {
 
 .rule-content-title h2 {
   padding: .5rem .75rem;
-  background-color: #f5f5f5;
+  margin: 0;
   border-left: 2px solid #cc4141; 
+}
+
+.rule-header-container .bookmark-icon, .rule-header-container .bookmark-icon-pressed {
+  margin-top: 1rem;
 }
 
 .rule-category-top p {
@@ -1580,7 +1584,7 @@ div.greybox {
 }
 
 .rule-content-title .rule-header-container {
-  background-color: #f5f5f5
+  background-color: #f5f5f5;
 }
 
 .edit-button-container::after {

--- a/src/style.css
+++ b/src/style.css
@@ -77,20 +77,8 @@ h4 {
   @apply mb-2;
 }
 
-.rule-content h1 a, .rule-content h2 a, .rule-content h3 a, .rule-content h4 a, .rule-content h5 a, .rule-content h6 a {
-  color: #cc4141;
-  text-decoration-color: #cc4141;
-  -webkit-text-decoration-thickness: 1px;
-  text-decoration-thickness: 1px;
-}
-
-.rule-content h1 a:hover, .rule-content h2 a:hover, .rule-content h3 a:hover, .rule-content h4 a:hover, .rule-content h5 a:hover, .rule-content h6 a:hover {
-  color: #222;
-  text-decoration-color: #222;
-}
-
-.rule-content a, .rule-content a:visited, .rule-header-container a, .rule-header-container a:visited {
-  &:not(.unstyled):not(.rule-content h1 a):not(.rule-content h2 a):not(.rule-content h3 a):not(.rule-content h4 a):not(.rule-content h5 a):not(.rule-content h6 a) {
+a, a:visited {
+  &:not(.unstyled) {
     color: #222;
     text-decoration: none;
     transition: color 0.25s ease;
@@ -760,7 +748,7 @@ b, strong {
 }
 
 .rule-content a, .rule-category-top a {
-  &:not(.unstyled):not(.action-btn-link):not(.action-btn-link-underlined):not(.info-btn-container):not(h1 a):not(h2 a):not(h3 a):not(h4 a):not(h5 a):not(h6 a) {
+  &:not(.unstyled):not(.action-btn-link):not(.action-btn-link-underlined):not(.info-btn-container) {
     transition: color 0.25s ease;
     line-height: 1.5rem;
     -webkit-text-decoration: underline;
@@ -778,6 +766,12 @@ b, strong {
       text-decoration-color: #cc4141;
     } 
   } 
+}
+
+.rule-content h1 a, .rule-content h1 a:visited, .rule-content h2 a, .rule-content h2 a:visited, .rule-content h3 a, .rule-content h3 a:visited, .rule-content h4 a, .rule-content h4 a:visited, .rule-content h5 a, .rule-content h5 a:visited, .rule-content h6 a, .rule-content h6 a:visited {
+  color: #cc4141;
+  text-decoration-color: #cc4141 !important;
+  -webkit-text-decoration-color: #cc4141;
 }
 
 h6.top-category-header,
@@ -1064,13 +1058,13 @@ blockquote p:before {
 
 .rule-content a,
 .rule-category a {
-  text-decoration-line: underline;
+  text-decoration: underline;
   transition: color 0.25s ease;
 }
 
 .rule-content a:hover,
 .rule-category a:hover:not(.github-link, .disqus-link, .get-username-btn::after) {
-  text-decoration:underline;;
+  text-decoration:underline;
   color: #cc4141;
 }
 

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -134,7 +134,7 @@ export default function Category({ data }) {
                       <li>
                         <section className="rule-content-title pl-2">
                           <div className="rule-header-container align-middle justify-between">
-                            <h2>
+                            <h2 className="flex flex-col justify-center">
                               <Link
                                 ref={linkRef}
                                 to={`/${rule.frontmatter.uri}`}

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -133,7 +133,7 @@ export default function Category({ data }) {
                     <>
                       <li>
                         <section className="rule-content-title pl-2">
-                          <div className="rule-header-container justify-between">
+                          <div className="rule-header-container align-middle justify-between">
                             <h2>
                               <Link
                                 ref={linkRef}


### PR DESCRIPTION
Fixes UI bugs introduced in #630 and #648

## Category headings were not centred vertically:

![image](https://user-images.githubusercontent.com/40375803/131287693-9bd99971-f034-423c-a105-8b0369fd8147.png)
**Figure: Category heading not centred vertically**

![image](https://user-images.githubusercontent.com/40375803/131287908-cfdcf235-211a-4630-82ce-4e89bfddac5b.png)
**Figure: Now centred**

## Body links not styled properly:

![image](https://user-images.githubusercontent.com/40375803/131287377-63cc42f7-2bb0-4534-8573-90731d61c29f.png)
**Figure: This is a link, but there is no styling to show that**

![image](https://user-images.githubusercontent.com/40375803/131287488-322a213b-b75e-4739-8484-dc3f083f5ffd.png)
**Figure: Link is now clearly visible as it originally was**