### PR TITLE
Improving and simplifying footer links

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -103,14 +103,11 @@ a, a:visited {
 }
 
 a.footer-link,a.footer-link:visited  {
-  @apply text-gray-300;
-  font-weight: bolder;
+  @apply text-white;
   line-height: .75rem;
   transition: all 0.3s ease-in-out;
-  text-decoration:underline;  
   &:hover {
     @apply text-ssw-red;
-    text-decoration:underline;
   }
 }
 


### PR DESCRIPTION
from
<img width="1256" alt="Screen Shot 2021-08-27 at 4 59 55 PM" src="https://user-images.githubusercontent.com/12601228/131410343-99133368-1453-454b-be2d-baf943ac38b9.png">

to
<img width="1093" alt="Screen Shot 2021-08-30 at 2 48 46 PM" src="https://user-images.githubusercontent.com/12601228/131410328-742ee807-ac73-4e65-8fc4-26e7e8044893.png">
