### PR TITLE
Simplify 'Read More' link

### DIFF
--- a/src/components/profile-content/profile-content.js
+++ b/src/components/profile-content/profile-content.js
@@ -24,6 +24,7 @@ import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
 import CommentsNotConnected from '../comments-not-connected/comments-not-connected';
 import DisableDisqusPrivacy from '../disable-disqus-privacy/disable-disqus-privacy';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const appInsights = new ApplicationInsights({
   config: {
@@ -467,9 +468,13 @@ const RuleList = ({
                     >
                       <div dangerouslySetInnerHTML={{ __html: rule.excerpt }} />
                       <p className="pt-5 pb-0">
-                        Read more about{' '}
-                        <Link ref={linkRef} to={`/${rule.uri}`}>
-                          {rule.title}
+                        <Link
+                          ref={linkRef}
+                          to={`/${rule.frontmatter.uri}`}
+                          state={{ category: category.parent.name }}
+                        >
+                          <FontAwesomeIcon icon={faArrowCircleRight} /> Read
+                          more
                         </Link>
                       </p>
                     </section>

--- a/src/components/profile-content/profile-content.js
+++ b/src/components/profile-content/profile-content.js
@@ -472,6 +472,7 @@ const RuleList = ({
                           ref={linkRef}
                           to={`/${rule.frontmatter.uri}`}
                           state={{ category: category.parent.name }}
+                          title={`Read more about ${rule.frontmatter.title}`}
                         >
                           <FontAwesomeIcon icon={faArrowCircleRight} /> Read
                           more

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -206,6 +206,7 @@ export default function Category({ data }) {
                               ref={linkRef}
                               to={`/${rule.frontmatter.uri}`}
                               state={{ category: category.parent.name }}
+                              title={`Read more about ${rule.frontmatter.title}`}
                             >
                               <FontAwesomeIcon icon={faArrowCircleRight} /> Read
                               more

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -7,7 +7,10 @@ import Breadcrumb from '../components/breadcrumb/breadcrumb';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import Bookmark from '../components/bookmark/bookmark';
-import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowCircleRight,
+  faPencilAlt,
+} from '@fortawesome/free-solid-svg-icons';
 
 export default function Category({ data }) {
   const linkRef = useRef();
@@ -198,14 +201,14 @@ export default function Category({ data }) {
                           <div
                             dangerouslySetInnerHTML={{ __html: rule.excerpt }}
                           />
-                          <p className="pt-5 pb-0">
-                            Read more about{' '}
+                          <p className="pt-5 pb-0 font-bold">
                             <Link
                               ref={linkRef}
                               to={`/${rule.frontmatter.uri}`}
                               state={{ category: category.parent.name }}
                             >
-                              {rule.frontmatter.title}
+                              <FontAwesomeIcon icon={faArrowCircleRight} /> Read
+                              more
                             </Link>
                           </p>
                         </section>


### PR DESCRIPTION
Closes #443 and PBI 60887

Simplified the 'read more' link to save room and avoid repeating the title on the screen. The title is still included in the title / hover text for Google juice.

![image](https://user-images.githubusercontent.com/40375803/131427809-00c423b2-f1d4-45a9-8401-e97387062195.png)
**Figure: Link simplified with hover text added**

