### PR TITLE
Finalise CodeAuditor pipeline

### DIFF
--- a/.azure/codeauditor-pipeline.yml
+++ b/.azure/codeauditor-pipeline.yml
@@ -23,3 +23,4 @@ stages:
   - job: Test
     steps:
     - template: templates/test.yml
+    

--- a/.azure/codeauditor-pipeline.yml
+++ b/.azure/codeauditor-pipeline.yml
@@ -7,7 +7,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: 0,30 * * * *
+- cron: 0 14 * * 0
   displayName: Scheduled CodeAuditor Test
   always: true
   branches:
@@ -22,11 +22,4 @@ stages:
   jobs:
   - job: Test
     steps:
-    - checkout: none
-
-    - task: Bash@3
-      displayName: 'SSW CodeAuditor - Check broken links and performance'
-      continueOnError: true
-      inputs:
-        targetType: 'inline'
-        script: 'docker run sswconsulting/codeauditor --token 3c34a549-dfb3-442c-b0e3-45942104a8bf --url https://www.ssw.com.au/rules/ --maxthread 200 --debug'
+    - template: templates/test.yml

--- a/.azure/production-pipelines.yml
+++ b/.azure/production-pipelines.yml
@@ -23,12 +23,3 @@ stages:
   - job: build
     steps:
     - template: templates/build.yml
-
-- stage: test
-  dependsOn: build
-  displayName: Tests - CodeAuditor
-  condition: succeeded()
-  jobs:
-  - job: Test
-    steps:
-    - template: templates/test.yml

--- a/.azure/production-pipelines.yml
+++ b/.azure/production-pipelines.yml
@@ -23,3 +23,4 @@ stages:
   - job: build
     steps:
     - template: templates/build.yml
+    


### PR DESCRIPTION
Closes #651 and PBI 63562

Removes CodeAuditor step from the build pipeline and sets the permanent schedule of the new scheduled CodeAuditor pipeline.

CodeAuditor tests will run every Monday at 12am (2pm Sunday UTC time).