### PR TITLE
Changed image max width to match container size

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,7 +119,7 @@ module.exports = {
               // the content container as this plugin uses this as the
               // base for generating different widths of each image.
               //linkImagesToOriginal: false,
-              maxWidth: 1024,
+              maxWidth: 1232,
               backgroundColor: 'transparent',
             },
           },


### PR DESCRIPTION
Closes #645 and PBI 63492

Updated max width of images in Gatsby to make images the same width as the content container.

![image](https://user-images.githubusercontent.com/40375803/132619690-731cd1c8-57d3-4210-b103-02f18a5e9546.png)
**Figure: Image is now the same width as email template**