### PR TITLE
🐛 Fix image stretching horizontally issue

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1130,6 +1130,7 @@ blockquote p:before {
 
 .rule-content img {
   max-width: 100%;
+  width: auto !important;
   border: 12px solid #eee;
   outline: 1px solid #ccc;
 }


### PR DESCRIPTION
(Checked by Jack)
Cc: @JackDevAU @pierssinclairssw @bradystroud @tiagov8

This PR addresses Issue #706 where images would be stretched beyond their normal dimensions by inline CSS set by Gatsby plugins. 

Changes:
- Update the Site.css for the .rules-content img with `width: auto !important;`

![Showing updated CSS and Image fixed](https://user-images.githubusercontent.com/17246482/141388376-3e7b6f94-ce77-44f0-ae97-e65ddc2cf8c1.png)
**Figure: Showing the updated CSS and the fixed image.**

**Note:** I was unable to replicate the vertical stretching with the second image (QR Code). In the case this PR doesn't fix that issue I will investigate further.
