### PR TITLE
🐛 Remove the extra /rules infront of the links

### DIFF
--- a/src/components/all-rules-content/allRulesContent.js
+++ b/src/components/all-rules-content/allRulesContent.js
@@ -64,6 +64,11 @@ const AllRulesContent = ({
     </span>
   );
 
+  const sanitizeRule = (item) => {
+    let rule = sanitizeName(item, true);
+    return rule.slice(6, rule.length);
+  };
+
   return (
     <section className="mb-5 relative">
       <Heading
@@ -77,7 +82,7 @@ const AllRulesContent = ({
               <div key={idx} className="cat-grid-container">
                 <div className="cat-rule-num">{idx + 1}.</div>
                 <div className="cat-rule-link">
-                  <Link to={`/${sanitizeName(item.item.fields.slug, true)}`}>
+                  <Link to={`/${sanitizeRule(item.item.fields.slug)}`}>
                     {item.item.frontmatter.title}
                   </Link>
                 </div>


### PR DESCRIPTION
<!-- Include the issue it closes -->
#711
<!-- Summarize your changes -->
Fixed the Rules URLs - (These were incorrectly linking you to `/rules/rules/<rule-uri>`)

![image](https://user-images.githubusercontent.com/57518417/142089656-5b64353e-2538-4363-a86a-5a6698e15f1e.png)
Figure: The Rules URL 