### PR TITLE
🐛 Have the MegaMenu content at 100% width

### DIFF
--- a/lib/ssw.megamenu/menu/menu.module.css
+++ b/lib/ssw.megamenu/menu/menu.module.css
@@ -43,8 +43,10 @@
 .menuContent {
   display: inline-block;
   float: left;
+  width: 100%;
 }
 .menuMobile {
+  width: 100%;
   float: left;
   position: relative;
 }


### PR DESCRIPTION
Cc: @JackDevAU @bradystroud 

- [x] Recommended extensions have been installed if using VS Code
 
<!-- Include the issue it closes -->
As per the issue from @tiagov8 
https://github.com/SSWConsulting/SSW.Rules/issues/762

<!-- Summarize your changes -->
Changes:
 - Update the Menu module css to make the content 100% width

<!-- include screenshots if relevant -->
![image](https://user-images.githubusercontent.com/17246482/143181854-7d45714e-04cf-4716-8915-0462bc065eca.png)

