### PR TITLE
✨ Add anchor tags to all h3s

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -121,6 +121,17 @@ module.exports = {
               backgroundColor: 'transparent',
             },
           },
+          {
+            resolve: 'gatsby-remark-autolink-headers',
+            options: {
+              offsetY: '100',
+              icon: '<svg aria-hidden="true" height="20" version="1.1" viewBox="0 0 16 16" width="20"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>',
+              maintainCase: false,
+              removeAccents: true,
+              isIconAfterHeader: true,
+              elements: ['h3'],
+            },
+          },
           'gatsby-remark-copy-linked-files',
           'gatsby-remark-fenced-divs',
           {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gatsby-plugin-react-helmet": "^5.1.0",
     "gatsby-plugin-sharp": "^3.13.0",
     "gatsby-plugin-sitemap": "^5.1.1",
+    "gatsby-remark-autolink-headers": "^5.2.0",
     "gatsby-remark-copy-linked-files": "^5.1.0",
     "gatsby-remark-custom-blocks": "^3.13.0",
     "gatsby-remark-embed-video": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10242,6 +10242,17 @@ gatsby-recipes@^0.24.0:
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
 
+gatsby-remark-autolink-headers@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.2.0.tgz#c5edd26011da8d27cc7f0b686e3e6ff9b7d7ad50"
+  integrity sha512-sPAT3qNEVXkInZk+bzt9xyfyFWVnU5BVaKK58SejkHptCHhKhw/0Ueq3C2rV/ZTqxiFTGYUW64UBtcq5b6nyKA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    github-slugger "^1.3.0"
+    lodash "^4.17.21"
+    mdast-util-to-string "^2.0.0"
+    unist-util-visit "^2.0.3"
+
 gatsby-remark-copy-linked-files@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-5.2.0.tgz#ff9a45ad1096631bba3442586cc2ebe8713dddcb"
@@ -10805,6 +10816,11 @@ github-slugger@^1.2.1:
   integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
+
+github-slugger@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.4.0.tgz#206eb96cdb22ee56fdc53a28d5a302338463444e"
+  integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
 
 glob-parent@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
<!-- You must complete the below task before your PR will be accepted -->
- [x] Recommended extensions have been installed if using VS Code
<!-- Include the issue it closes -->
#701 [#1801](https://github.com/SSWConsulting/SSW.Rules.Content/issues/1801)
<!-- Summarize your changes -->
- Added a Gatsby plugin that adds anchor tags to all `h3` elements.
<!-- include screenshots if relevant -->
![image](https://user-images.githubusercontent.com/57518417/143388910-7e3de354-1741-4422-bed4-b3d3de939f4e.png)
**Figure: shareable/linkable headings**