### PR TITLE
Serve history feed

### DIFF
--- a/src/helpers/historyFeedGenerator.js
+++ b/src/helpers/historyFeedGenerator.js
@@ -4,7 +4,9 @@ const createHistoryFeed = async (pluginData, pages, graphql) => {
   const { publicFolder } = pluginData;
   const FILE_PATH = publicFolder('history-feed.json');
   const pageData = Array.from(pages.values()).map((page) => {
+    console.log(page);
     return {
+      path: page.path,
       id: page.context.id,
       file: page.context.file,
       title: page.context.title,
@@ -16,6 +18,7 @@ const createHistoryFeed = async (pluginData, pages, graphql) => {
     query {
       history: allHistoryJson(
         sort: { fields: lastUpdated, order: DESC }
+        filter: { file: { glob: "rules/**" } }
         limit: 10
       ) {
         edges {
@@ -34,17 +37,16 @@ const createHistoryFeed = async (pluginData, pages, graphql) => {
   //TODO: Fix this code block
   const nodes = Array.from(
     result.data.history.edges.map(({ node }) => {
-      var currentPage = pageData.find((x) => (x.file = node.file));
-      //TODO: Remove this console log
-      console.log(currentPage);
+      var currentPage = pageData.find((x) => node.file == x.file);
+
       return {
         id: node.id,
         lastUpdated: node.lastUpdated,
         lastUpdatedBy: node.lastUpdatedBy,
         lastUpdatedByEmail: node.lastUpdatedByEmail,
         file: node.file,
-        title: currentPage.title,
-        uri: currentPage.uri,
+        title: currentPage?.title ?? 'No title',
+        uri: currentPage?.uri ?? 'not-found',
       };
     })
   );

--- a/src/helpers/historyFeedGenerator.js
+++ b/src/helpers/historyFeedGenerator.js
@@ -1,0 +1,59 @@
+const fs = require('fs-extra');
+
+const createHistoryFeed = async (pluginData, pages, graphql) => {
+  const { publicFolder } = pluginData;
+  const FILE_PATH = publicFolder('history-feed.json');
+  const pageData = Array.from(pages.values()).map((page) => {
+    return {
+      id: page.context.id,
+      file: page.context.file,
+      title: page.context.title,
+      uri: page.context.uri,
+    };
+  });
+
+  const result = await graphql(`
+    query {
+      history: allHistoryJson(
+        sort: { fields: lastUpdated, order: DESC }
+        limit: 10
+      ) {
+        edges {
+          node {
+            id
+            file
+            lastUpdated
+            lastUpdatedBy
+            lastUpdatedByEmail
+          }
+        }
+      }
+    }
+  `);
+
+  //TODO: Fix this code block
+  const nodes = Array.from(
+    result.data.history.edges.map(({ node }) => {
+      var currentPage = pageData.find((x) => (x.file = node.file));
+      //TODO: Remove this console log
+      console.log(currentPage);
+      return {
+        id: node.id,
+        lastUpdated: node.lastUpdated,
+        lastUpdatedBy: node.lastUpdatedBy,
+        lastUpdatedByEmail: node.lastUpdatedByEmail,
+        file: node.file,
+        title: currentPage.title,
+        uri: currentPage.uri,
+      };
+    })
+  );
+
+  const data = `[ ${nodes.map((x) => JSON.stringify(x)).join(',')} ]`;
+
+  return fs.writeFile(FILE_PATH, data);
+};
+
+module.exports = {
+  createHistoryFeed,
+};

--- a/src/helpers/historyFeedGenerator.js
+++ b/src/helpers/historyFeedGenerator.js
@@ -4,7 +4,6 @@ const createHistoryFeed = async (pluginData, pages, graphql) => {
   const { publicFolder } = pluginData;
   const FILE_PATH = publicFolder('history-feed.json');
   const pageData = Array.from(pages.values()).map((page) => {
-    console.log(page);
     return {
       path: page.path,
       id: page.context.id,


### PR DESCRIPTION
Cc: @christianmorfordwaitessw @JackDevAU @bradystroud @pierssinclairssw 

<!-- You must complete the below task before your PR will be accepted -->
- [x] Recommended extensions have been installed if using VS Code
<!-- Include the issue it closes -->
No issue - This PR aims to provide a cleaner and faster way to serve our History data to the Rules.Widget

<!-- Summarize your changes -->
Changes:
- Adding functionality to the onPostBuild for Gatsby to compile a history-feed.json for the Rules Widget to point to

<!-- include screenshots if relevant -->
