### PR TITLE
💄 UI - Make logo text unselectable

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -38,7 +38,9 @@ const Header = ({ displayActions }) => {
               >
                 <SSWLogo aria-label="logo" width="113.5" height="75.5" />
               </a>
-              <h1 className="title ml-2">Rules</h1>
+              <a href="/">
+                <h1 className="title unselectable ml-2">Rules</h1>
+              </a>
             </div>
             <p className={displayActions ? 'tagline-hidden' : 'tagline'}>
               Secret ingredients to quality software

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -5,9 +5,9 @@ const NotFound = () => {
   return (
     <div className="not-found-page">
       <div className="not-found-grid">
-        <h1>404</h1>
+        <h1 className="unselectable">404</h1>
         <div className="not-found-message">
-          <h2>
+          <h2 className="unselectable">
             The verdict is in... <p />
             SSW Rules has concluded that this page is <span>NOT FOUND!</span>
           </h2>

--- a/src/style.css
+++ b/src/style.css
@@ -3034,3 +3034,10 @@ margin-bottom: 1em;
 .rule-content tr:nth-child(even) {
   background-color: #F6F8FA;
 }
+
+.unselectable {
+  user-select: none;
+  -webkit-user-select: none; /* Safari 3.1+ */
+  -moz-user-select: none; /* Firefox 2+ */
+  -ms-user-select: none; /* IE 10+ */
+}


### PR DESCRIPTION
<!-- You must complete the below task before your PR will be accepted -->
- [ ] Recommended extensions have been installed if using VS Code

<!-- Include the issue it closes -->
#503 

<!-- Summarize your changes -->
Changes:
 - Created a css class that makes things unselectable by the user.
 - Updated the "Rules" text next to the SSW logo to be unselectable
 - Updated the "Rules" text next to the SSW logo to link to https://ssw.com.au/rules
 - Updated the 404 page text to be unselectable

<!-- include screenshots if relevant -->
