### PR TITLE
Fixing background for transparent images

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1085,6 +1085,7 @@ blockquote p:before {
   width: auto !important;
   border: 12px solid #eee;
   outline: 1px solid #ccc;
+  background-color: #eee;
 }
 
 .rule-content .acknowledgements img {


### PR DESCRIPTION
cc @hashemelhossainissw

Example: https://www.ssw.com.au/rules/ppt-test-please
The image is showing a white separator because the bg is white and the border is #eee 

Added CSS to make background the same color as the border, so transparent images look good.

<img width="202" alt="Screen Shot 2022-03-08 at 5 05 37 PM" src="https://user-images.githubusercontent.com/12601228/157352403-c7e6005d-9566-4c0c-9e4b-bcdf80aa6744.png">




