### PR TITLE
Fixing borders on paste to Outlook

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,10 @@
   font-weight: normal;
   font-style: normal;
 }
+
+*, ::before, ::after {
+  border-style: none;
+}
  
 html {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif


### PR DESCRIPTION
Fixed as per https://tailwindcss.com/docs/preflight#border-styles-are-reset-globally

When pasting on Outlook content got borders because of Tailwind reset

![Picture3](https://user-images.githubusercontent.com/12601228/160488975-0ce14eb0-9457-43dc-a3ff-18197ba8c046.png)

