### PR TITLE
Header - Align SSW Logo with word Rules

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -386,10 +386,6 @@ button:focus {
   color: #cc4141;
 }
 
-.ssw-logo {
-  margin-top: 0.85rem;
-}
-
 .bg-ssw-red {
   background-color: #cc4141;
 }


### PR DESCRIPTION
SSW logo and the word Rules is miss-aligned on header. Removed margin top to fix this

<img width="443" alt="Screen Shot 2022-03-29 at 9 17 07 AM" src="https://user-images.githubusercontent.com/12601228/160658894-7870c518-4f96-41ca-b5fb-fbb64e1e2541.png">

