### PR TITLE
🐛 - multiple quotes - only 1st has double quote

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -805,6 +805,11 @@ blockquote p:before {
   margin-right: 0.2em;
 }
 
+blockquote p:after {
+  content: no-close-quote;
+}
+
+
 .radio-toolbar input[type="radio"] {
   opacity: 0;
   position: fixed;


### PR DESCRIPTION
.

<!-- You must complete the below task before your PR will be accepted -->
- [ ] Recommended extensions have been installed if using VS Code
<!-- Include the issue it closes -->
🐛 SSW.Rules CSS - multiple quotes - only the 1st has a double quote
<!-- Summarize your changes -->
@tiagov8 @bradystroud I added a style to the blockquote closing the quotations, previously all the subsequent quotes were being treated as part of the first quote.
<!-- include screenshots if relevant -->
