### PR TITLE
Adding margin to the 404 page specific class

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2347,7 +2347,8 @@ div.bad-example {
 }
 
 .not-found-greybox {
-  margin: auto;
+  margin-top: 16px;
+  margin-bottom: 16px;
 }
 
 @media (max-width: 850px) {


### PR DESCRIPTION
adding a top and bottom margin to the "not-found-greybox" class so that the spacing of the rules 404 page is consistent with the other 404 pages on People and the website.

<!-- You must complete the below task before your PR will be accepted -->
- [x] Recommended extensions have been installed if using VS Code
<!-- Include the issue it closes -->

<!-- Summarize your changes -->

<!-- include screenshots if relevant -->
![image](https://user-images.githubusercontent.com/97079655/187595879-9b06ca5a-04ea-42a8-8c59-20cc216f7b1a.png)
**Figure: current rules 404 page**

![image](https://user-images.githubusercontent.com/97079655/187596100-bb50b8a0-09f0-4514-a1bf-d19a16a87f3c.png)
**Figure:Peoples 404 page**