### PR TITLE
Give margin to tables

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1260,7 +1260,7 @@ div.bad-example {
   font-weight: bold;
   padding: 1rem;
   display: table;
-  margin: 0 0 1rem;
+  margin: 1rem 0;
   border: 1px solid red;
 }
 
@@ -1287,7 +1287,7 @@ div.bad-example {
 .rule-content .info, .rule-content .china, .rule-content .codeauditor {
   display: block;
   padding: 1rem;
-  margin: 0 0 1rem;
+  margin: 1rem 0;
   max-width: 100%;
   min-height: 4.5rem;
   border: 1px solid #ccc;
@@ -2947,6 +2947,10 @@ margin-bottom: 1em;
 
 /* Rule content tables
 -------------------------------------------------- */
+.rule-content table {
+  margin: 1rem 0;
+}
+
 .rule-content td {
   border: 1px solid #E0E2E5;
   padding: 0.375rem 0.8125rem;


### PR DESCRIPTION
This is to solve the problem of having no space after a table:
E.g. https://ssw.com.au/rules/different-types-of-testing 

<img width="945" alt="Screen Shot 2022-12-19 at 1 40 48 PM" src="https://user-images.githubusercontent.com/12601228/208530127-c3256685-f697-4a37-a1d4-dc7c7eb8fa24.png">
