### PR TITLE
items span full screen when on small screen

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -914,7 +914,13 @@ blockquote p:after {
 }
 
 .rule-category ol {
-  padding-inline-start: 20px;
+  padding-inline-start: 0px;
+}
+
+@media only screen and (min-width: 640px) {
+    .rule-category ol {
+      padding-inline-start: 20px;
+    }
 }
 
 .cat-title-grid-container {

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -165,8 +165,8 @@ export default function Category({ data }) {
                 </label>
               </div>
             </div>
-            <div className="category-rule">
-              <ol className="rule-number">
+            <div className="category-rule p-0 sm:p-[2.2rem]">
+              <ol className="rule-number list-none sm:list-decimal">
                 {category.frontmatter.index.map((r, i) => {
                   var rule = rules.find((rr) => rr.frontmatter.uri == r);
                   if (!rule) {
@@ -175,7 +175,7 @@ export default function Category({ data }) {
                   return (
                     <div key={i}>
                       <li key={i}>
-                        <section className="rule-content-title pl-2">
+                        <section className="rule-content-title sm:pl-2">
                           <div className="rule-header-container align-middle justify-between">
                             <h2 className="flex flex-col justify-center">
                               <Link

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -173,7 +173,7 @@ export default function Category({ data }) {
                     return;
                   }
                   return (
-                    <div key={i}>
+                    <div key={i} className="mb-3">
                       <li key={i}>
                         <section className="rule-content-title sm:pl-2">
                           <div className="rule-header-container align-middle justify-between">


### PR DESCRIPTION
CC: @adamcogan 

<!-- You must complete the below task before your PR will be accepted -->
- [x] Recommended extensions have been installed if using VS Code
<!-- Include the issue it closes -->
As per an email task from @adamcogan, the content was too thin to read on smaller screens. This PR fixes this by spanning the content the full screen width on smaller devices.

<!-- Summarize your changes -->

<!-- include screenshots if relevant -->
![image](https://user-images.githubusercontent.com/25432120/217971191-fd95d514-bd57-44a6-9ba7-f7a0580c41d8.png)
**Figure: Content spans full screen when on small width**