### PR TITLE
Made blockquotes :before " only show in the 1st paragraph

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -798,7 +798,7 @@ blockquote footer {
   margin-top: 1rem;
 }
 
-blockquote p:before {
+blockquote p:first-child:before {
   color: #ccc;
   content: open-quote;
   font-size: 4em;


### PR DESCRIPTION
cc @jaydenalchin 

Made blockquotes :before " only show in the 1st paragraph

Example rule of what I want to fix: https://ssw.com.au/rules/fix-problems-quickly/ 

<img width="337" alt="Screenshot 2023-03-02 at 9 28 38 AM" src="https://user-images.githubusercontent.com/12601228/222505771-6f3cb8df-15f9-48bd-b0b3-6a28b5f05733.png">

Related Issue: https://github.com/SSWConsulting/SSW.Rules/issues/844 
