### PR TITLE
Added call to action at the bottom of categories

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -93,6 +93,8 @@ exports.createPages = async ({ graphql, actions }) => {
           frontmatter {
             index
             redirects
+            experts
+            consulting
           }
           parent {
             ... on File {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -46,6 +46,8 @@ exports.createSchemaCustomization = ({ actions }) => {
       authors: [Author]
       related: [String]
       redirects: [String]
+      experts: String
+      consulting: String
       guid: String
     }
     type Author {

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -45,6 +45,7 @@ export default function Category({ data }) {
     .filter((r) => {
       return category.frontmatter.index.includes(r.frontmatter.uri);
     });
+
   return (
     <div>
       <Breadcrumb
@@ -271,6 +272,40 @@ export default function Category({ data }) {
             </div>
           </section>
         </div>
+
+        {(category.frontmatter.consulting || category.frontmatter.experts) && (
+          <div className="flex flex-col items-center justify-center gap-4">
+            <h3 className="text-3xl">
+              Need some help with{' '}
+              <span className="text-ssw-red">
+                {category.frontmatter.title.replace('Rules to', '')}
+              </span>
+              ?
+            </h3>
+
+            {category.frontmatter.consulting && (
+              <button
+                className="bg-ssw-red text-white px-5 py-3 text-lg"
+                onClick={() =>
+                  window.open(category.frontmatter.consulting, '_blank')
+                }
+              >
+                See our consulting services
+              </button>
+            )}
+
+            {category.frontmatter.experts && (
+              <Link
+                to={category.frontmatter.experts}
+                className="group unstyled"
+              >
+                <span className="text-lg font-medium underline decoration-underline duration-150 group-hover:decoration-ssw-red group-hover:text-ssw-red transition ease-in-out delay-75">
+                  Meet our experts
+                </span>
+              </Link>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -288,6 +323,8 @@ export const query = graphql`
       frontmatter {
         title
         archivedreason
+        consulting
+        experts
         index
         uri
         guid

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -323,11 +323,11 @@ export const query = graphql`
       frontmatter {
         title
         archivedreason
-        consulting
-        experts
         index
         uri
         guid
+        consulting
+        experts
       }
       parent {
         ... on File {
@@ -344,6 +344,8 @@ export const query = graphql`
           archivedreason
           title
           guid
+          consulting
+          experts
         }
         htmlAst
       }


### PR DESCRIPTION
## Description
Added call to action at the bottom of category pages.

This can now be edited through GitHub by adding the following fields to a category md file.
```md
experts: https://www.ssw.com.au/people/?skill={{skill}}
consulting: https://www.ssw.com.au/consulting/{{consulting-page}}
```

The following documentation has been updated to include the new fields:
https://github.com/SSWConsulting/SSW.Rules.Content/wiki/How-to-Add-and-Edit-Categories-and-Top-Categories

## Images
![image](https://github.com/SSWConsulting/SSW.Rules/assets/25432120/6e7b266c-ca80-4897-87dc-cd5ef585c6a3)
**Figure: New call to action at bottom of page**