### PR TITLE
🔨 Move lint to GitHub action

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -50,9 +50,6 @@ steps:
 - script: yarn install --frozen-lockfile
   displayName: yarn install
 
-- script: yarn lint
-  displayName: yarn lint
-
 - script: |
     mv .env.template .env.production
     cat .env.production

--- a/.github/workflows/pr-lint-code.yml
+++ b/.github/workflows/pr-lint-code.yml
@@ -1,0 +1,27 @@
+name: PR - Lint code
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.event.number }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  lint-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - run: yarn install
+
+      - run: yarn lint --max-warnings 0

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,11 +26,11 @@ const Index = ({ data, location }) => {
       <Breadcrumb isHomePage={true} />
       <div className="container" id="rules">
         <div className="flex flex-wrap">
-          <div className="w-full lg:w-3/4 px-4">            
+          <div className="w-full lg:w-3/4 px-4">
             <span className="flex items-center">
               <h2 className="flex-1">Categories</h2>
               <Link to={'/latest-rules?size=10'} className="group unstyled">
-                <FontAwesomeIcon               
+                <FontAwesomeIcon
                   icon={faBolt}
                   size={30}
                   className="group-hover:text-ssw-red transition ease-in-out delay-75 duration-150"


### PR DESCRIPTION
Move PR linting to GitHub action

Benifits of this
- Seperate from build
- Can see the error without going to DevOps
- Simplifies overall architecture

<img width="1253" alt="image" src="https://github.com/SSWConsulting/SSW.Rules/assets/38869720/c406155d-77c5-440a-808a-4f97278ca769">

https://github.com/SSWConsulting/SSW.Rules/issues/993

Tested on my fork
