### PR TITLE
Added warning to edit tooltip due to Netlify issues

### DIFF
--- a/src/pages/orphaned.js
+++ b/src/pages/orphaned.js
@@ -205,7 +205,13 @@ const Orphaned = ({ data }) => {
                                     className="bookmark-icon"
                                   />
                                 </a>
-                                <span className="tooltiptext">Edit</span>
+                                <span className="tooltiptext w-52 !-left-[4.6rem]">
+                                  Edit
+                                  <p>
+                                    (Warning: Stale branches can cause issues -
+                                    See wiki for help)
+                                  </p>
+                                </span>
                               </button>
                               <button className="tooltip">
                                 <a

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -210,7 +210,13 @@ export default function Category({ data }) {
                                     className="bookmark-icon"
                                   />
                                 </a>
-                                <span className="tooltiptext">Edit</span>
+                                <span className="tooltiptext w-52 !-left-[4.6rem]">
+                                  Edit
+                                  <p>
+                                    (Warning: Stale branches can cause issues -
+                                    See wiki for help)
+                                  </p>
+                                </span>
                               </button>
                               <button className="tooltip">
                                 <a

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -193,7 +193,13 @@ const Rule = ({ data, location }) => {
                           className="bookmark-icon"
                         />
                       </a>
-                      <span className="tooltiptext">Edit</span>
+                      <span className="tooltiptext w-52 !-left-[4.6rem]">
+                        Edit
+                        <p>
+                          (Warning: Stale branches can cause issues - See wiki
+                          for help)
+                        </p>
+                      </span>
                     </button>
                     <button className="tooltip">
                       <a


### PR DESCRIPTION
Added warning to edit tooltip due to Netlify issues

Related to #1003 

![image](https://github.com/SSWConsulting/SSW.Rules/assets/25432120/13cb16ee-1d14-41ef-b17a-0bd7b6471420)
**Figure: New tooltip message**