### PR TITLE
Removed ID tag from SVG images

### DIFF
--- a/src/images/bookmarkIcon.svg
+++ b/src/images/bookmarkIcon.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="60px" height="100px" viewBox="0 0 60 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="Welcome" stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd">
-        <g id="Bookmark2" transform="translate(-1173.000000, -107.000000)" fill="currentColor">
-            <g id="Rectangle" transform="translate(1173.000000, 107.000000)">
+    <g stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd">
+        <g transform="translate(-1173.000000, -107.000000)" fill="currentColor">
+            <g transform="translate(1173.000000, 107.000000)">
                 <path d="M5,0 L55,0 C57.7614237,-5.07265313e-16 60,2.23857625 60,5 L60,100 L60,100 L30,79.1691588 L0,100 L0,5 C-3.38176876e-16,2.23857625 2.23857625,5.07265313e-16 5,0 Z"></path>
             </g>
         </g>

--- a/src/images/gavel.svg
+++ b/src/images/gavel.svg
@@ -4,17 +4,17 @@
 <style type="text/css">
 	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#CC4141;}
 </style>
-<g id="UG-Pages">
+<g>
 	
-		<g id="Group" transform="translate(97.000000, 97.000000) rotate(-45.000000) translate(-97.000000, -97.000000) translate(33.000000, 25.000000)">
+		<g transform="translate(97.000000, 97.000000) rotate(-45.000000) translate(-97.000000, -97.000000) translate(33.000000, 25.000000)">
 		
-			<rect id="Rectangle" x="31.6" y="11.6" transform="matrix(-1 2.535182e-06 -2.535182e-06 -1 127.154 70.1287)" class="st0" width="64" height="47"/>
-		<path id="Rectangle-Copy-20" class="st0" d="M6.6-2.4h15.1c3.9,0,7,3.1,7,7v61.1c0,3.9-3.1,7-7,7H6.6c-3.9,0-7-3.1-7-7V4.5
+			<rect x="31.6" y="11.6" transform="matrix(-1 2.535182e-06 -2.535182e-06 -1 127.154 70.1287)" class="st0" width="64" height="47"/>
+		<path class="st0" d="M6.6-2.4h15.1c3.9,0,7,3.1,7,7v61.1c0,3.9-3.1,7-7,7H6.6c-3.9,0-7-3.1-7-7V4.5
 			C-0.4,0.7,2.7-2.4,6.6-2.4z"/>
-		<path id="Rectangle-Copy-20_00000008855576442547208690000015596132193793320591_" class="st0" d="M105.6-2.4h15.1
+		<path class="st0" d="M105.6-2.4h15.1
 			c3.9,0,7,3.1,7,7v61.1c0,3.9-3.1,7-7,7h-15.1c-3.9,0-7-3.1-7-7V4.5C98.6,0.7,101.7-2.4,105.6-2.4z"/>
 		
-			<rect id="Rectangle-Copy-18" x="45.6" y="54.6" transform="matrix(-1 2.535181e-06 -2.535181e-06 -1 128.1541 196.1287)" class="st0" width="37" height="87"/>
+			<rect x="45.6" y="54.6" transform="matrix(-1 2.535181e-06 -2.535181e-06 -1 128.1541 196.1287)" class="st0" width="37" height="87"/>
 	</g>
 </g>
 </svg>


### PR DESCRIPTION
This fixes the error "Tags - Id attributes must be unique" as the same SVG would occur multiple times on the same page leading to a "non-unique ID"

Changes:
```
❯ git diff
diff --git a/src/images/bookmarkIcon.svg b/src/images/bookmarkIcon.svg
index 2beedea..0be3bb9 100644
--- a/src/images/bookmarkIcon.svg
+++ b/src/images/bookmarkIcon.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="60px" height="100px" viewBox="0 0 60 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="Welcome" stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd">
-        <g id="Bookmark2" transform="translate(-1173.000000, -107.000000)" fill="currentColor">
-            <g id="Rectangle" transform="translate(1173.000000, 107.000000)">
+    <g stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd">
+        <g transform="translate(-1173.000000, -107.000000)" fill="currentColor">
+            <g transform="translate(1173.000000, 107.000000)">
                 <path d="M5,0 L55,0 C57.7614237,-5.07265313e-16 60,2.23857625 60,5 L60,100 L60,100 L30,79.1691588 L0,100 L0,5 C-3.38176876e-16,2.23857625 2.23857625,5.07265313e-16 5,0 Z"></path>
             </g>
         </g>
     </g>
-</svg>
\ No newline at end of file
+</svg>
diff --git a/src/images/gavel.svg b/src/images/gavel.svg
index 1a20e7c..4581c04 100644
--- a/src/images/gavel.svg
+++ b/src/images/gavel.svg
@@ -4,17 +4,17 @@
 <style type="text/css">
        .st0{fill-rule:evenodd;clip-rule:evenodd;fill:#CC4141;}
 </style>
-<g id="UG-Pages">
+<g>
        
-               <g id="Group" transform="translate(97.000000, 97.000000) rotate(-45.000000) translate(-97.000000, -97.000000) translate(33.000000, 25.000000)">
+               <g transform="translate(97.000000, 97.000000) rotate(-45.000000) translate(-97.000000, -97.000000) translate(33.000000, 25.000000)">
                
-                       <rect id="Rectangle" x="31.6" y="11.6" transform="matrix(-1 2.535182e-06 -2.535182e-06 -1 127.154 70.1287)" class="st0" width="64" height="47"/>
-               <path id="Rectangle-Copy-20" class="st0" d="M6.6-2.4h15.1c3.9,0,7,3.1,7,7v61.1c0,3.9-3.1,7-7,7H6.6c-3.9,0-7-3.1-7-7V4.5
+                       <rect x="31.6" y="11.6" transform="matrix(-1 2.535182e-06 -2.535182e-06 -1 127.154 70.1287)" class="st0" width="64" height="47"/>
+               <path class="st0" d="M6.6-2.4h15.1c3.9,0,7,3.1,7,7v61.1c0,3.9-3.1,7-7,7H6.6c-3.9,0-7-3.1-7-7V4.5
                        C-0.4,0.7,2.7-2.4,6.6-2.4z"/>
-               <path id="Rectangle-Copy-20_00000008855576442547208690000015596132193793320591_" class="st0" d="M105.6-2.4h15.1
+               <path class="st0" d="M105.6-2.4h15.1
                        c3.9,0,7,3.1,7,7v61.1c0,3.9-3.1,7-7,7h-15.1c-3.9,0-7-3.1-7-7V4.5C98.6,0.7,101.7-2.4,105.6-2.4z"/>
                
-                       <rect id="Rectangle-Copy-18" x="45.6" y="54.6" transform="matrix(-1 2.535181e-06 -2.535181e-06 -1 128.1541 196.1287)" class="st0" width="37" height="87"/>
+                       <rect x="45.6" y="54.6" transform="matrix(-1 2.535181e-06 -2.535181e-06 -1 128.1541 196.1287)" class="st0" width="37" height="87"/>
```
