### PR TITLE
Added way to navigate to rules homepage via header logo

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -49,7 +49,9 @@ const Header = ({ displayActions }) => {
               >
                 <SSWLogo aria-label="logo" width="113.5" height="75.5" />
               </a>
-              <h1 className="title ml-2">Rules</h1>
+              <h1 className="title ml-2">
+                <a href="/rules">Rules</a>
+              </h1>
             </div>
             <p className={displayActions ? 'tagline-hidden' : 'tagline'}>
               Secret ingredients to quality software


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->
Rules header is now clickable and will navigate to rules homepage

Related #504

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
