### PR TITLE
Added hints to "redirects" and "related" fields in CMS

### DIFF
--- a/src/cms/config.js
+++ b/src/cms/config.js
@@ -80,6 +80,7 @@ var configJson = {
             field: {
               name: 'relatedRule',
               label: 'Rule uri',
+              hint: 'The URI for the related rule, i.e. label-your-assets',
               pattern: [
                 '^[a-z0-9_-]*$',
                 'Must only contain lowercase alphanumeric or the "-" and "_" characters',
@@ -94,6 +95,7 @@ var configJson = {
             field: {
               name: 'redirectUri',
               label: 'Redirect uri',
+              hint: 'The URI for the old rule, i.e. label-your-assets',
             },
           },
           {


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->
CC: @tiagov8 

As per my conversation with @bradystroud, we will just be adding hint text. Adding prefilled text will break validation and cause more work on the backend to remove the prefixed text "https://ssw.com.au/"

![image](https://github.com/SSWConsulting/SSW.Rules/assets/25432120/4f35649b-3056-4a08-85f9-ad16c3997605)

Relates to #718

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
