### PR TITLE
🔎 Optimize Search by Lazy-loading

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,8 +14,6 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-local-search',
       options: {
-        // A unique name for the search index. This should be descriptive of
-        // what the index contains. This is required.
         name: 'pages',
         engine: 'flexsearch',
         engineOptions: 'speed',
@@ -26,7 +24,6 @@ module.exports = {
               id
               frontmatter {
                 title
-                archivedreason
               }
               fields {
                 slug
@@ -36,32 +33,13 @@ module.exports = {
           }
         }
         `,
-        ref: 'id',
-        // List of keys to index. The values of the keys are taken from the
-        // normalizer function below.
-        index: ['id', 'frontmatter.title', 'rawMarkdownBody'],
-        // List of keys to store and make available in your UI. The values of
-        // the keys are taken from the normalizer function below.
-        store: [
-          'id',
-          'frontmatter.title',
-          'frontmatter.archivedreason',
-          'fields.slug',
-        ],
-        // Function used to map the result from the GraphQL query. This should
-        // return an array of items to index in the form of flat objects
-        // containing properties to index. The objects must contain the `ref`
-        // field above (default: 'id'). This is required.
+        ref: 'slug',
+        index: ['slug', 'title', 'rawMarkdownBody'],
+        store: ['slug', 'title'],
         normalizer: ({ data }) =>
           data.allMarkdownRemark.nodes.map((node) => ({
-            id: node.id,
-            frontmatter: {
-              title: node.frontmatter.title,
-              archivedreason: node.frontmatter.archivedreason,
-            },
-            fields: {
-              slug: node.fields.slug,
-            },
+            slug: node.fields.slug,
+            title: node.frontmatter.title,
             rawMarkdownBody: node.rawMarkdownBody,
           })),
       },

--- a/src/components/search-bar/search-bar.js
+++ b/src/components/search-bar/search-bar.js
@@ -1,25 +1,49 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useFlexSearch } from 'react-use-flexsearch';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
-const SearchBar = ({ searchQuery, setSearchQuery }) => (
-  <form className="border border-solid w-96 ml-4 flex items-center pl-3 p-2 rounded shadow bg-gray-50">
-    <FontAwesomeIcon icon={faSearch} size="lg" className="text-gray-400 mr-2" />
-    <input
-      value={searchQuery}
-      onInput={(e) => setSearchQuery(e.target.value)}
-      type="text"
-      id="header-search"
-      placeholder="I'm looking for..."
-      className="w-full outline-none bg-gray-50"
-    />
-  </form>
-);
+const SearchBar = ({
+  searchQuery,
+  setSearchQuery,
+  index,
+  store,
+  setSearchResult,
+}) => {
+  let searchResult;
+  if (index && store) {
+    searchResult = useFlexSearch(searchQuery, index, store);
+  }
+
+  useEffect(() => {
+    setSearchResult(searchResult);
+  }, [searchResult, setSearchResult]);
+
+  return (
+    <form className="border border-solid w-96 ml-4 flex items-center pl-3 p-2 rounded shadow bg-gray-50">
+      <FontAwesomeIcon
+        icon={faSearch}
+        size="lg"
+        className="text-gray-400 mr-2"
+      />
+      <input
+        value={searchQuery}
+        onInput={(e) => setSearchQuery(e.target.value)}
+        type="text"
+        placeholder="I'm looking for..."
+        className="w-full outline-none bg-gray-50"
+      />
+    </form>
+  );
+};
 
 export default SearchBar;
 
 SearchBar.propTypes = {
-  searchQuery: PropTypes.func.isRequired,
+  searchQuery: PropTypes.string.isRequired,
   setSearchQuery: PropTypes.func.isRequired,
+  index: PropTypes.string.isRequired,
+  store: PropTypes.object.isRequired,
+  setSearchResult: PropTypes.func.isRequired,
 };

--- a/src/pages/latest-rules.js
+++ b/src/pages/latest-rules.js
@@ -42,7 +42,7 @@ const LatestRules = ({ data, location }) => {
   }, [filter, isAscending, searchQuery]);
 
   const filterAndValidateRules = async () => {
-    const selectedRules = searchQuery ? searchResult : rules;
+    const selectedRules = searchQuery ? unFlattenResults(searchResult) : rules;
     const foundRules = await selectedRules.map((item) => {
       //TODO: Depending on the speed - optimise this find
       let findRule = history.find(
@@ -102,6 +102,13 @@ const LatestRules = ({ data, location }) => {
     setFilteredItems({
       list: filteredRules.slice(0, queryStringRulesListSize),
       filter: _filter,
+    });
+  };
+
+  const unFlattenResults = (results) => {
+    return results.map((x) => {
+      const { title, slug } = x;
+      return { frontmatter: { title }, fields: { slug } };
     });
   };
 

--- a/src/pages/latest-rules.js
+++ b/src/pages/latest-rules.js
@@ -1,5 +1,6 @@
 import Filter, { FilterOptions } from '../components/filter/filter';
 import React, { useEffect, useState } from 'react';
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
 import LatestRulesContent from '../components/latest-rules-content/latestRulesContent';
 import Breadcrumb from '../components/breadcrumb/breadcrumb';
@@ -9,6 +10,14 @@ import { graphql } from 'gatsby';
 import { objectOf } from 'prop-types';
 import qs from 'query-string';
 import { sanitizeName } from '../helpers/sanitizeName';
+
+const appInsights = new ApplicationInsights({
+  config: {
+    instrumentationKey: process.env.APPINSIGHTS_INSTRUMENTATIONKEY,
+  },
+});
+
+appInsights.loadAppInsights();
 
 const LatestRules = ({ data, location }) => {
   const [filter, setFilter] = useState();
@@ -51,8 +60,11 @@ const LatestRules = ({ data, location }) => {
         const storeResponse = await fetch(publicStoreURL);
         const storeData = await storeResponse.json();
         setSearchStore(storeData);
-      } catch (error) {
-        console.error(error);
+      } catch (err) {
+        appInsights.trackException({
+          error: new Error(err),
+          severityLevel: 3,
+        });
       }
     };
 

--- a/src/pages/latest-rules.js
+++ b/src/pages/latest-rules.js
@@ -1,6 +1,5 @@
 import Filter, { FilterOptions } from '../components/filter/filter';
 import React, { useEffect, useState } from 'react';
-import { useFlexSearch } from 'react-use-flexsearch';
 
 import LatestRulesContent from '../components/latest-rules-content/latestRulesContent';
 import Breadcrumb from '../components/breadcrumb/breadcrumb';
@@ -17,6 +16,9 @@ const LatestRules = ({ data, location }) => {
   const [filteredItems, setFilteredItems] = useState({ list: [], filter: {} });
   const [isAscending, setIsAscending] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchIndex, setSearchIndex] = useState(null);
+  const [searchStore, setSearchStore] = useState(null);
+  const [searchResult, setSearchResult] = useState(null);
 
   const filterTitle = 'Results';
   const history = data.allHistoryJson.edges;
@@ -25,9 +27,6 @@ const LatestRules = ({ data, location }) => {
   const queryStringSearch = qs.parse(location?.search, {
     parseNumbers: true,
   });
-
-  const { index, store } = data.localSearchPages;
-  const searchResult = useFlexSearch(searchQuery, index, store);
 
   const queryStringRulesListSize = (() => {
     if (!queryStringSearch.size) {
@@ -39,7 +38,26 @@ const LatestRules = ({ data, location }) => {
 
   useEffect(() => {
     filterAndSort(filter);
-  }, [filter, isAscending, searchQuery]);
+  }, [filter, isAscending, searchResult]);
+
+  useEffect(() => {
+    const { publicIndexURL, publicStoreURL } = data.localSearchPages;
+    const fetchData = async () => {
+      try {
+        const indexResponse = await fetch(publicIndexURL);
+        const indexData = await indexResponse.text();
+        setSearchIndex(indexData);
+
+        const storeResponse = await fetch(publicStoreURL);
+        const storeData = await storeResponse.json();
+        setSearchStore(storeData);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchData();
+  }, []);
 
   const filterAndValidateRules = async () => {
     const selectedRules = searchQuery ? unFlattenResults(searchResult) : rules;
@@ -115,7 +133,15 @@ const LatestRules = ({ data, location }) => {
   return (
     <div className="w-full">
       <Breadcrumb isLatest />
-      <SearchBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+      {searchIndex && searchStore && (
+        <SearchBar
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          index={searchIndex}
+          store={searchStore}
+          setSearchResult={setSearchResult}
+        />
+      )}
       <div className="container" id="rules">
         <div className="flex flex-wrap">
           <div className="w-full lg:w-3/4 px-4">
@@ -147,8 +173,8 @@ const LatestRules = ({ data, location }) => {
 export const pageQuery = graphql`
   query latestRulesQuery {
     localSearchPages {
-      index
-      store
+      publicIndexURL
+      publicStoreURL
     }
     allHistoryJson {
       edges {


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1033

The search feature is currently making the page render slow because the Markdown data is too large in both staging and production. To solve this, we are trying the use of [Local Search - Lazy-loading the index and store](https://www.gatsbyjs.com/plugins/gatsby-plugin-local-search/#lazy-loading-the-index-andor-store) to reduce the time it takes to fetch the data.

Changes:
- Added lazy-loading for the seach component
- Made the search bar visible only after the data is fetched
- Added application insights
<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
