### PR TITLE
🐛Fix styling for ol nested under ul

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -167,7 +167,7 @@ footer {
   margin-top: -20px;
 }
 
-#rules ul li::before, .rule-content ul li::before, .rule-category-top ul li::before {
+#rules ul > li::before, .rule-content ul > li::before, .rule-category-top ul > li::before {
   content: "\25A0";
   color: #cc4141;
   display: inline-block; 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->
When using an `ol` nested under a `ul`, it gets a combination of the styling for both. This PR fixes the styling by requiring that an `li` is a direct child of a `ul` to receive a bullet

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->
![image](https://github.com/SSWConsulting/SSW.Rules/assets/7465195/81120f19-0b69-424d-9f5e-948bc8eb7a9b)
**Figure: Before - `ol` has a mixture of number and bullet**

![image](https://github.com/SSWConsulting/SSW.Rules/assets/7465195/42b42ce0-1002-4674-ba1f-335ff7267b5c)
**Figure: After - `ol` only has a number**

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
