### PR TITLE
🐛Fix search relative path

### DIFF
--- a/src/components/search-bar/search-bar.js
+++ b/src/components/search-bar/search-bar.js
@@ -6,11 +6,9 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons';
 const SearchBar = ({ searchQuery, setSearchQuery, toSearch }) => {
   const handlePressEnter = (val) => {
     if (!toSearch || !searchQuery) return;
-    if (process.env.NODE_ENV === 'development') {
-      window.location.href = `/search?keyword=${val}`;
-    } else {
-      window.location.href = `/rules/search?keyword=${val}`;
-    }
+
+    const pathPrefix = process.env.NODE_ENV === 'development' ? '' : '/rules';
+    window.location.href = `${pathPrefix}/search?keyword=${val}`;
   };
 
   return (

--- a/src/components/search-bar/search-bar.js
+++ b/src/components/search-bar/search-bar.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { navigate } from 'gatsby';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
 const SearchBar = ({ searchQuery, setSearchQuery, toSearch }) => {
   const handlePressEnter = (val) => {
     if (!toSearch || !searchQuery) return;
-    window.location.href = `/search?string=${val}`;
+    navigate(`/search?keyword=${val}`);
   };
 
   return (

--- a/src/components/search-bar/search-bar.js
+++ b/src/components/search-bar/search-bar.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { navigate } from 'gatsby';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
 const SearchBar = ({ searchQuery, setSearchQuery, toSearch }) => {
   const handlePressEnter = (val) => {
     if (!toSearch || !searchQuery) return;
-    navigate(`/search?keyword=${val}`);
+    if (process.env.NODE_ENV === 'development') {
+      window.location.href = `/search?keyword=${val}`;
+    } else {
+      window.location.href = `/rules/search?keyword=${val}`;
+    }
   };
 
   return (

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -37,7 +37,7 @@ const LatestRules = ({ data, location }) => {
   }, [filter, isAscending, searchResult]);
 
   useEffect(() => {
-    const searchString = qs.parse(location?.search).string;
+    const searchString = qs.parse(location?.search).keyword;
     if (searchString) {
       setSearchQuery(searchString);
     }


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1033

The link to the search is missing a path prefix "/rules/", which needs to be added in staging and production to ensure that we can access the search page.

Changes:
- Added "/rules/" based on the node environment variables
<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
