### PR TITLE
💄Fix Heading Tag

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -49,9 +49,9 @@ const Header = ({ displayActions }) => {
               >
                 <SSWLogo aria-label="logo" width="113.5" height="75.5" />
               </a>
-              <h1 className="title ml-2">
+              <div className="my-4 leading-[1.2] ml-2 text-[2.5rem]">
                 <a href="/rules">Rules</a>
-              </h1>
+              </div>
             </div>
             <p className={displayActions ? 'tagline-hidden' : 'tagline'}>
               Secret ingredients to quality software

--- a/src/pages/latest-rules.js
+++ b/src/pages/latest-rules.js
@@ -139,7 +139,7 @@ const LatestRules = ({ data, location }) => {
         <div className="flex flex-wrap">
           <div className="w-full lg:w-3/4 px-4">
             <span className="flex">
-              <h2 className="flex-1">Latest Rules</h2>
+              <h1 className="flex-1 text-3xl">Latest Rules</h1>
               <div className="flex items-center align-middle">
                 <Filter selected={setFilter} />
               </div>

--- a/src/style.css
+++ b/src/style.css
@@ -59,12 +59,6 @@ h1 {
   @apply text-ssw-red;
 }
 
-h1.title {
-  font-size: 2.5em;
-  color: #414141;
-  margin-bottom: 0.1em;
-}
-
 h2 {
   @apply text-3xl;
   @apply mb-2;
@@ -801,11 +795,6 @@ blockquote p:after {
   min-height: 4.25rem;
 }
 
-.cat-title-grid-container h2.cat-title {
-  margin: 0;
-  color: #333;
-}
-
 .cat-title-grid-container .rule-count {
   letter-spacing: normal;
   color: #ccc;
@@ -847,7 +836,6 @@ blockquote p:after {
 -------------------------------------------------- */
 
 .rule-category h1 {
-  color: #cc4141;
   font-weight: 100;
 }
 

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -67,12 +67,12 @@ export default function Category({ data }) {
         <div className="rule-category rounded">
           <section className="mb-20 rounded pb-2">
             <div className="cat-title-grid-container">
-              <h2 className="cat-title">
+              <h1 className="text-ssw-black font-medium text-3xl">
                 {category.frontmatter.title}
                 <span className="rule-count">
                   {' - '} {rules.length} {rules.length > 1 ? 'Rules' : 'Rule'}
                 </span>
-              </h2>
+              </h1>
 
               <Tooltip text="Edit in GitHub">
                 <button className="mt-1 justify-self-end">


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1070 

Changes:
- Made logo text "Rules" a `div`
- Changed category title to `h1`
- Made "Latest Rules" title a `h1`
<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->
![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/cdb9bcd5-51d5-4ec2-bbb4-406036966591)
**Figure: The UI is the same before and after the changes😉**

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
