### PR TITLE
Removed slash at end of RulesGPT link

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -62,7 +62,7 @@ const Header = ({ displayActions }) => {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://rulesgpt.ssw.com.au/"
+                href="https://rulesgpt.ssw.com.au"
                 className="action-btn-link-underlined"
                 onClick={() => {
                   appInsights.trackEvent({


### PR DESCRIPTION
Removed the slash at end of RulesGPT link that was violating https://ssw.com.au/rules/no-full-stop-or-slash-at-the-end-of-urls/
