### PR TITLE
Added contentDigest field 

### DIFF
--- a/src/helpers/algolia-queries.js
+++ b/src/helpers/algolia-queries.js
@@ -11,15 +11,20 @@ const pageQuery = `{
             fields {
                 slug
             }
+            internal {
+              # querying internal.contentDigest is required - https://github.com/algolia/gatsby-plugin-algolia#partial-updates
+              contentDigest
+            }
         }
     }
 }`;
 
-function pageToAlgoliaRecord({ id, frontmatter, fields, ...rest }) {
+function pageToAlgoliaRecord({ id, frontmatter, fields, internal, ...rest }) {
   return {
     objectID: id,
     ...frontmatter,
     ...fields,
+    ...internal,
     ...rest,
   };
 }


### PR DESCRIPTION
Added `contentDigest` field as per https://github.com/algolia/gatsby-plugin-algolia#partial-updates

<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to build issues happening on prod
<img width="1215" alt="Screenshot 2023-09-18 at 09 26 38" src="https://github.com/SSWConsulting/SSW.Rules/assets/25432120/7cb8e4db-9547-41b3-86a7-789026a61096">

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
