### PR TITLE
add correct digest path

### DIFF
--- a/src/helpers/algolia-queries.js
+++ b/src/helpers/algolia-queries.js
@@ -24,7 +24,9 @@ function pageToAlgoliaRecord({ id, frontmatter, fields, internal, ...rest }) {
     objectID: id,
     ...frontmatter,
     ...fields,
-    contentDigest: internal.contentDigest,
+    internal: {
+      contentDigest: internal.contentDigest
+    },
     ...rest,
   };
 }

--- a/src/helpers/algolia-queries.js
+++ b/src/helpers/algolia-queries.js
@@ -1,4 +1,4 @@
-const indexName = "Rules";
+const indexName = 'Rules';
 
 const pageQuery = `{
     pages: allMarkdownRemark(filter: { frontmatter: { type: { eq: "rule" } } }) {
@@ -36,7 +36,7 @@ const queries = [
     query: pageQuery,
     transformer: ({ data }) => data.pages.nodes.map(pageToAlgoliaRecord),
     indexName,
-    settings: { attributesToSnippet: ["excerpt:20"] },
+    settings: { attributesToSnippet: ['excerpt:20'] },
   },
 ];
 

--- a/src/helpers/algolia-queries.js
+++ b/src/helpers/algolia-queries.js
@@ -1,4 +1,4 @@
-const indexName = 'Rules';
+const indexName = "Rules";
 
 const pageQuery = `{
     pages: allMarkdownRemark(filter: { frontmatter: { type: { eq: "rule" } } }) {
@@ -25,7 +25,7 @@ function pageToAlgoliaRecord({ id, frontmatter, fields, internal, ...rest }) {
     ...frontmatter,
     ...fields,
     internal: {
-      contentDigest: internal.contentDigest
+      contentDigest: internal.contentDigest,
     },
     ...rest,
   };
@@ -36,7 +36,7 @@ const queries = [
     query: pageQuery,
     transformer: ({ data }) => data.pages.nodes.map(pageToAlgoliaRecord),
     indexName,
-    settings: { attributesToSnippet: ['excerpt:20'] },
+    settings: { attributesToSnippet: ["excerpt:20"] },
   },
 ];
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->
Hopefully fixes the below issue by adding an `internal` object with `contentDigest` as a param. 
```
error the objects must have internal.contentDigest. Current object:
{
  "objectID": "47dcddc2-65bd-5c02-b04b-f6f3cf324cb7",
  "title": "Do you avoid changing the URL on a 404 error?",
  "slug": "/rules/404-error-avoid-changing-the-url/rule/",
  "contentDigest": "dae846231767afd7b132d5db7147224d",
  "excerpt": "When you request a URL of a file that doesn't exist, you will get an error message. You should make sure that the URL in the browser doesn't change. This way, it's easy for the user to correct.  E.g. The user doesn't have to retype the whole URL if there is a spelling mistake or a forgotten/mixed up letter."
}

```


Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1102

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
