### PR TITLE
gatsby-node now only processes md files that have 'rule' as it's type

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -106,11 +106,7 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
       rules: allMarkdownRemark(
-        filter: {
-          frontmatter: {
-            type: { nin: ["category", "top-category", "main", "diagram"] }
-          }
-        }
+        filter: { frontmatter: { type: { in: ["rule"] } } }
       ) {
         nodes {
           fields {


### PR DESCRIPTION
Updated gatsby-node config to only process MD files that have 'rule' set as it's type within the front-matter.

<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1110

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
