### PR TITLE
Add UpdateLatest rules to the pipeline 

### DIFF
--- a/.azure/scripts/update-latest-rules.ps1
+++ b/.azure/scripts/update-latest-rules.ps1
@@ -1,0 +1,19 @@
+param (
+    [string]$AzFunctionBaseUrl,
+    [string]$UpdateLatestRulesFunctionKey
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Uri = $AzFunctionBaseUrl + '/api/UpdateLatestRules'
+$Headers = @{'x-functions-key' = $UpdateLatestRulesFunctionKey}
+
+# Send a POST request 
+Invoke-RestMethod -Uri $Uri -Method Post -Headers $Headers
+
+$responseObject = ConvertFrom-Json -InputObject $ResponseBody
+if ($responseObject.message -eq "Latest rules updated successfully.") {
+    Write-Host "Latest rules updated successfully!"
+} else {
+    Write-Error "Error updating Latest rules: $responseObject.message"
+}

--- a/.azure/update-rule-history.yml
+++ b/.azure/update-rule-history.yml
@@ -30,3 +30,12 @@ steps:
         -UpdateRuleHistoryKey $(UpdateRuleHistoryKey)
         -UpdateHistorySyncCommitHashKey $(UpdateHistorySyncCommitHashKey)
     displayName: 'Get Rule History Commits'
+
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/SSW.Rules/.azure/scripts/update-latest-rules.ps1
+      arguments: > # Use this to avoid newline characters in multiline string
+        -AzFunctionBaseUrl $(AzFunctionBaseUrl)
+        -UpdateLatestRulesFunctionKey $(UpdateLatestRulesFunctionKey)
+    displayName: 'Update Latest Rules'

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,7 +7,6 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 const DirectoryNamedWebpackPlugin = require('directory-named-webpack-plugin');
 const path = require('path');
 const Map = require('core-js/features/map');
-const { pathPrefix } = require('./site-config');
 
 if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
   // Log build time stats to appInsights

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -199,7 +199,7 @@ exports.createPages = async ({ graphql, actions }) => {
         related: node.frontmatter.related ? node.frontmatter.related : [''],
         uri: node.frontmatter.uri,
         redirects: node.frontmatter.redirects,
-        file: `${pathPrefix}/${node.frontmatter.uri}/rule.md`,
+        file: `rules/${node.frontmatter.uri}/rule.md`,
         title: node.frontmatter.title,
       },
     });


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1152 & https://github.com/SSWConsulting/SSW.Rules/issues/1171#issuecomment-1849154265

- Adds a new .ps1 script to the pipeline to update the Latest Rules Table 
- Hopefully fixes the metadata issue. Stopped using `pathPrefix` from `site-config.js` for `file` var as it didn't match the gatsby graphql query 


## Q. 

Not sure where to add `$UpdateLatestRulesFunctionKey`

<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
