### PR TITLE
🐛 Fix Sandbox Error

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -213,6 +213,7 @@ module.exports = {
                     `https://www.youtube-nocookie.com/embed/${videoId}`,
                 },
               ], //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
+              sandbox: "'allow-same-origin allow-scripts allow-presentation'",
             },
           },
           'gatsby-remark-responsive-iframe',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -213,6 +213,7 @@ module.exports = {
                     `https://www.youtube-nocookie.com/embed/${videoId}`,
                 },
               ], //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
+              /* eslint-disable quotes */
               sandbox: "'allow-same-origin allow-scripts allow-presentation'",
             },
           },


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1172 

**Note: The use of double quotes is necessary as mentioned in this PR: https://github.com/borgfriend/gatsby-remark-embed-video/pull/181**

Fixes this error message: `Uncaught DOMException: Failed to construct 'PresentationRequest': The document is sandboxed and lacks the 'allow-presentation' flag.`
![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/3a32e107-5f6f-4b9a-88c1-714cea559679)



<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
