### PR TITLE
Images are served as webp on compatible browsers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -139,6 +139,9 @@ module.exports = {
               //linkImagesToOriginal: false,
               maxWidth: 1024,
               backgroundColor: 'transparent',
+              withWebp: {
+                quality: 100,
+              },
             },
           },
           {


### PR DESCRIPTION
Images are now served as webp on compatible browsers
