### PR TITLE
✨ Remember View Mode Selection

### DIFF
--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -39,15 +39,15 @@ export default function Category({ data }) {
 
   useEffect(() => {
     setShowViewButton(true);
-    setLocalOption()
+    setLocalOption();
   }, []);
 
   const setLocalOption = () => {
     if (typeof window !== 'undefined') {
-      const viewModeOption = localStorage.getItem('viewModeOption') || 'all'
-      setSelectedOption(viewModeOption)
+      const viewModeOption = localStorage.getItem('viewModeOption') || 'all';
+      setSelectedOption(viewModeOption);
     }
-  }
+  };
 
   const handleOptionChange = (e) => {
     setSelectedOption(e.target.value);

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -33,7 +33,9 @@ export default function Category({ data }) {
   const linkRef = useRef();
   const category = data.markdownRemark;
 
-  const [selectedOption, setSelectedOption] = useState(localStorage.getItem('viewModeOption') || 'all');
+  const [selectedOption, setSelectedOption] = useState(
+    localStorage.getItem('viewModeOption') || 'all'
+  );
   const [showViewButton, setShowViewButton] = useState(false);
   const [includeArchived, setIncludeArchived] = useState(false);
 

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -33,15 +33,21 @@ export default function Category({ data }) {
   const linkRef = useRef();
   const category = data.markdownRemark;
 
-  const [selectedOption, setSelectedOption] = useState(
-    localStorage.getItem('viewModeOption') || 'all'
-  );
+  const [selectedOption, setSelectedOption] = useState('all');
   const [showViewButton, setShowViewButton] = useState(false);
   const [includeArchived, setIncludeArchived] = useState(false);
 
   useEffect(() => {
     setShowViewButton(true);
+    setLocalOption()
   }, []);
+
+  const setLocalOption = () => {
+    if (typeof window !== 'undefined') {
+      const viewModeOption = localStorage.getItem('viewModeOption') || 'all'
+      setSelectedOption(viewModeOption)
+    }
+  }
 
   const handleOptionChange = (e) => {
     setSelectedOption(e.target.value);

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -33,7 +33,7 @@ export default function Category({ data }) {
   const linkRef = useRef();
   const category = data.markdownRemark;
 
-  const [selectedOption, setSelectedOption] = useState('all');
+  const [selectedOption, setSelectedOption] = useState(localStorage.getItem('viewModeOption') || 'all');
   const [showViewButton, setShowViewButton] = useState(false);
   const [includeArchived, setIncludeArchived] = useState(false);
 
@@ -43,6 +43,7 @@ export default function Category({ data }) {
 
   const handleOptionChange = (e) => {
     setSelectedOption(e.target.value);
+    localStorage.setItem('viewModeOption', e.target.value);
   };
 
   const handleIncludeArchivedChange = () => {


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1286

Remember the view mode selection by storing the users' choice in local storage. This approach ensures
- A cleaner URL for share links
- Permanent storage of user choices, even when they return later


https://github.com/SSWConsulting/SSW.Rules/assets/127192800/eb42b3da-53ac-4bd5-8a0f-2cba330185eb



<!-- Add done video, screenshots as per https://ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
