### PR TITLE
👷 Improve Build Time - Fixed Yarn Cache Path

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -20,7 +20,7 @@ steps:
     restoreKeys: |
       yarn | "$(Agent.OS)"
       yarn
-    path: $(yarn config get cacheFolder)
+    path: $(Pipeline.Workspace)/s/.yarn
 
 - task: Cache@2
   displayName: Cache Gatsby .cache


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1216 

Fixed the cache path for yarn packages to prevent Gatsby from deleting all saved pages.

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
