### PR TITLE
Deploy Infra - Add workflow permission

### DIFF
--- a/.github/workflows/template-deploy.yml
+++ b/.github/workflows/template-deploy.yml
@@ -8,6 +8,9 @@ on:
         required: true
         description: 'The environment to deploy to'
 
+permissions:
+  id-token: write
+
 jobs:
   deploy-infra:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-deploy.yml
+++ b/.github/workflows/template-deploy.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   deploy-infra:


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1301

set permission with `id-token:write` at workflow level to fix this error:
![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/1a106e37-7beb-4dcb-bef0-0f744b2f9694)


<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
