### PR TITLE
🔍 SEO - Add Meta Description

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -50,7 +50,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       experts: String
       consulting: String
       guid: String
-      description: String
+      seoDescription: String
     }
     type Author implements Node @dontInfer {
       title: String
@@ -124,7 +124,7 @@ exports.createPages = async ({ graphql, actions }) => {
             archivedreason
             related
             redirects
-            description
+            seoDescription
           }
         }
       }
@@ -204,7 +204,7 @@ exports.createPages = async ({ graphql, actions }) => {
         redirects: node.frontmatter.redirects,
         file: `rules/${node.frontmatter.uri}/rule.md`,
         title: node.frontmatter.title,
-        description: node.frontmatter.description,
+        seoDescription: node.frontmatter.seoDescription,
       },
     });
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -50,6 +50,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       experts: String
       consulting: String
       guid: String
+      description: String
     }
     type Author implements Node @dontInfer {
       title: String
@@ -123,6 +124,7 @@ exports.createPages = async ({ graphql, actions }) => {
             archivedreason
             related
             redirects
+            description
           }
         }
       }
@@ -202,6 +204,7 @@ exports.createPages = async ({ graphql, actions }) => {
         redirects: node.frontmatter.redirects,
         file: `rules/${node.frontmatter.uri}/rule.md`,
         title: node.frontmatter.title,
+        description: node.frontmatter.description,
       },
     });
   });

--- a/src/cms/config.js
+++ b/src/cms/config.js
@@ -40,6 +40,7 @@ var configJson = {
             default: 'rule',
           },
           { name: 'title', label: 'Title' },
+          { name: 'description', label: 'Description' },
           {
             name: 'uri',
             label: 'uri (a unique identifier for the url)',

--- a/src/cms/config.js
+++ b/src/cms/config.js
@@ -40,7 +40,7 @@ var configJson = {
             default: 'rule',
           },
           { name: 'title', label: 'Title' },
-          { name: 'description', label: 'Description' },
+          { name: 'seoDescription', label: 'Seo Description' },
           {
             name: 'uri',
             label: 'uri (a unique identifier for the url)',

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -12,6 +12,7 @@ const Head = ({
   siteUrl,
   parentSiteUrl,
   pageTitle,
+  pageDescription,
   themeColor,
   social,
   imageUrl,
@@ -46,9 +47,15 @@ const Head = ({
       <meta content={pageTitleFull} name="twitter:title" />
       <title>{pageTitleFull}</title>
 
-      <meta content={siteDescription} name="description" />
-      <meta content={siteDescription} property="og:description" />
-      <meta content={siteDescription} name="twitter:description" />
+      <meta content={pageDescription || siteDescription} name="description" />
+      <meta
+        content={pageDescription || siteDescription}
+        property="og:description"
+      />
+      <meta
+        content={pageDescription || siteDescription}
+        name="twitter:description"
+      />
 
       <meta content="yes" name="apple-mobile-web-app-capable" />
       <meta
@@ -198,6 +205,7 @@ Head.propTypes = {
   siteTitle: PropTypes.string,
   siteTitleShort: PropTypes.string,
   siteDescription: PropTypes.string,
+  pageDescription: PropTypes.string,
   siteUrl: PropTypes.string,
   parentSiteUrl: PropTypes.string,
   themeColor: PropTypes.string,

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -12,7 +12,7 @@ const Head = ({
   siteUrl,
   parentSiteUrl,
   pageTitle,
-  pageDescription,
+  seoDescription,
   themeColor,
   social,
   imageUrl,
@@ -47,13 +47,13 @@ const Head = ({
       <meta content={pageTitleFull} name="twitter:title" />
       <title>{pageTitleFull}</title>
 
-      <meta content={pageDescription || siteDescription} name="description" />
+      <meta content={seoDescription || siteDescription} name="description" />
       <meta
-        content={pageDescription || siteDescription}
+        content={seoDescription || siteDescription}
         property="og:description"
       />
       <meta
-        content={pageDescription || siteDescription}
+        content={seoDescription || siteDescription}
         name="twitter:description"
       />
 
@@ -205,7 +205,7 @@ Head.propTypes = {
   siteTitle: PropTypes.string,
   siteTitleShort: PropTypes.string,
   siteDescription: PropTypes.string,
-  pageDescription: PropTypes.string,
+  seoDescription: PropTypes.string,
   siteUrl: PropTypes.string,
   parentSiteUrl: PropTypes.string,
   themeColor: PropTypes.string,

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -15,7 +15,7 @@ const Layout = ({
   displayActions,
   ruleUri,
   crumbLabel,
-  pageDescription,
+  seoDescription,
 }) => {
   const node = useRef();
   const [isMenuOpened, setIsMenuOpened] = useState(false);
@@ -56,7 +56,7 @@ const Layout = ({
               pageTitle={
                 crumbLabel == 'SSW Rules' ? 'Latest Rules' : crumbLabel
               }
-              pageDescription={pageDescription}
+              seoDescription={seoDescription}
             />
             <Header displayActions={displayActions} ruleUri={ruleUri} />
             <main className="flex-1">{children}</main>
@@ -76,7 +76,7 @@ Layout.propTypes = {
   pageTitle: PropTypes.string,
   crumbLocation: PropTypes.object,
   crumbLabel: PropTypes.string,
-  pageDescription: PropTypes.string,
+  seoDescription: PropTypes.string,
 };
 
 function LayoutWithQuery(props) {

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -10,7 +10,13 @@ import { Auth0Provider } from '@auth0/auth0-react';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 
 config.autoAddCss = false;
-const Layout = ({ children, displayActions, ruleUri, crumbLabel }) => {
+const Layout = ({
+  children,
+  displayActions,
+  ruleUri,
+  crumbLabel,
+  pageDescription,
+}) => {
   const node = useRef();
   const [isMenuOpened, setIsMenuOpened] = useState(false);
 
@@ -50,6 +56,7 @@ const Layout = ({ children, displayActions, ruleUri, crumbLabel }) => {
               pageTitle={
                 crumbLabel == 'SSW Rules' ? 'Latest Rules' : crumbLabel
               }
+              pageDescription={pageDescription}
             />
             <Header displayActions={displayActions} ruleUri={ruleUri} />
             <main className="flex-1">{children}</main>
@@ -69,6 +76,7 @@ Layout.propTypes = {
   pageTitle: PropTypes.string,
   crumbLocation: PropTypes.object,
   crumbLabel: PropTypes.string,
+  pageDescription: PropTypes.string,
 };
 
 function LayoutWithQuery(props) {

--- a/src/helpers/wrapPageElement.js
+++ b/src/helpers/wrapPageElement.js
@@ -24,6 +24,7 @@ const wrapPageElement = ({ element, props }) => {
             ? siteConfig.homepageTitle
             : siteConfig.breadcrumbDefault
       }
+      pageDescription={markdown?.frontmatter?.description}
       displayActions={markdown ? true : false}
       ruleUri={markdown ? markdown.parent.relativePath : null}
     >

--- a/src/helpers/wrapPageElement.js
+++ b/src/helpers/wrapPageElement.js
@@ -24,7 +24,7 @@ const wrapPageElement = ({ element, props }) => {
             ? siteConfig.homepageTitle
             : siteConfig.breadcrumbDefault
       }
-      pageDescription={markdown?.frontmatter?.description}
+      seoDescription={markdown?.frontmatter?.seoDescription}
       displayActions={markdown ? true : false}
       ruleUri={markdown ? markdown.parent.relativePath : null}
     >

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -325,6 +325,7 @@ export const query = graphql`
         created(formatString: "DD MMM YYYY")
         archivedreason
         related
+        description
       }
       parent {
         ... on File {

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -325,7 +325,7 @@ export const query = graphql`
         created(formatString: "DD MMM YYYY")
         archivedreason
         related
-        description
+        seoDescription
       }
       parent {
         ... on File {


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1305 

Changes:
- Using our custom description when generating pages if a description is present in the frontmatter
- Including a description field in the CMS editor

![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/c8110c9d-051f-48c3-931e-a51031576367)

**Figure: The rule's page using custom description**


![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/e805162b-aabf-441f-983d-4d124bf53917)
**Figure: New description field in the CMS editor**

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
