### PR TITLE
Fix rules history script

### DIFF
--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
 
-  syncHistory:
+  sync-history:
     name: Sync Rules History
     uses: ./.github/workflows/template-update-rules-history.yml
     with:
@@ -28,7 +28,9 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
+    needs:
+      - build
+      - sync-history
     name: Deploy
     uses: ./.github/workflows/template-deploy.yml
     with:

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -14,7 +14,7 @@ cd SSW.Rules.Content/
 git commit-graph write --reachable --changed-paths
 
 #Step 1: GetHistorySyncCommitHash - Retrieve CommitHash from AzureFunction
-$Uri = $AzFunctionBaseUrl + 'GetHistorySyncCommitHash'
+$Uri = $AzFunctionBaseUrl + '/GetHistorySyncCommitHash'
 $Headers = @{'x-functions-key' = $GetHistorySyncCommitHashKey}
 $Response = Invoke-WebRequest -URI $Uri -Headers $Headers
 $startCommitHash = $Response.Content -replace '"', ''
@@ -67,14 +67,14 @@ $historyArray | Foreach-Object {
 $historyFileContents = ConvertTo-Json $historyFileArray
 
 #Step 3: UpdateRuleHistory - Send History Patch to AzureFunction
-$Uri = $AzFunctionBaseUrl + 'UpdateRuleHistory'
+$Uri = $AzFunctionBaseUrl + '/UpdateRuleHistory'
 $Headers = @{'x-functions-key' = $UpdateRuleHistoryKey}
 $Response = Invoke-WebRequest -Uri $Uri -Method Post -Body $historyFileContents -Headers $Headers -ContentType 'application/json; charset=utf-8'
 
 if(![string]::IsNullOrWhiteSpace($commitSyncHash))
 {
     #Step 4: UpdateHistorySyncCommitHash - Update Commit Hash with AzureFunction
-    $Uri = $AzFunctionBaseUrl + 'UpdateHistorySyncCommitHash'
+    $Uri = $AzFunctionBaseUrl + '/UpdateHistorySyncCommitHash'
     $Headers = @{'x-functions-key' = $UpdateHistorySyncCommitHashKey}
     $Body = @{
         commitHash  = $commitSyncHash


### PR DESCRIPTION
Fixed issue where deploy script did not generate urls correctly - previous implementation assumed that base url would have trailing slash

Fixes #1335 

![CleanShot 2024-05-10 at 09 54 53](https://github.com/SSWConsulting/SSW.Rules/assets/600044/45cf59df-7c07-4699-9ee8-0e0843bdf083)

Figure: Error when running script
