### PR TITLE
💚GitHub Action - Set Timeout for Build

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -164,6 +164,7 @@ jobs:
         run: yarn build
         env:
           GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
+        timeout-minutes: 60
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1337

Added timeout (60 mins) to the action step.
![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/abd02c8e-fd2f-4e83-bf64-b8651fa43608)



<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
