### PR TITLE
🐛 Fix Incorrect Default Title in Page Source

### DIFF
--- a/site-config.js
+++ b/site-config.js
@@ -1,6 +1,14 @@
 /*eslint quotes: ["warn", "backtick"]*/
 /** @type {import('gatsby').GatsbyConfig} */
 
+const titles = {
+  '/latest-rules/': 'Latest Rules',
+  '/user/': 'User Rules',
+  '/orphaned/': 'Orphaned Rules',
+  '/archived/': 'Archived Rules',
+  '/profile/': 'Profile',
+};
+
 module.exports = {
   siteTitle: `SSW.Rules`,
   siteTitleShort: `SSW.Rules`,
@@ -19,4 +27,5 @@ module.exports = {
   breadcrumbDefault: `SSW Rules`,
   homepageTitle: `Secret Ingredients to Quality Software`,
   trailingSlash: `never`,
+  titles: titles,
 };

--- a/site-config.js
+++ b/site-config.js
@@ -2,11 +2,11 @@
 /** @type {import('gatsby').GatsbyConfig} */
 
 const titles = {
-  '/latest-rules/': 'Latest Rules',
-  '/user/': 'User Rules',
-  '/orphaned/': 'Orphaned Rules',
-  '/archived/': 'Archived Rules',
-  '/profile/': 'Profile',
+  '/latest-rules/': `Latest Rules`,
+  '/user/': `User Rules`,
+  '/orphaned/': `Orphaned Rules`,
+  '/archived/': `Archived Rules`,
+  '/profile/': `Profile`,
 };
 
 module.exports = {

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -4,8 +4,7 @@ import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 import { Location } from '@reach/router';
 import schemaGenerator from '../../helpers/schemaGenerator';
-import { pathPrefix, homepageTitle } from '../../../site-config';
-import titles from '../../helpers/config/pageTitles';
+import { pathPrefix, homepageTitle, titles } from '../../../site-config';
 
 const Head = ({
   siteTitle,

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 import { Location } from '@reach/router';
 import schemaGenerator from '../../helpers/schemaGenerator';
-import { pathPrefix } from '../../../site-config';
+import { pathPrefix, homepageTitle } from '../../../site-config';
 
 const Head = ({
   siteTitle,
@@ -18,8 +18,10 @@ const Head = ({
   imageUrl,
   location,
 }) => {
-  const generateTitle = (path, pageTitle = '') => {
+  const generateTitle = (path, pageTitle) => {
     const titles = {
+      '/latest-rules/': 'Latest Rules',
+      '/user/': 'User Rules',
       '/orphaned/': 'Orphaned Rules',
       '/archived/': 'Archived Rules',
       '/profile/': 'Profile',

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -39,7 +39,10 @@ const Head = ({
     return `${siteTitle} | ${homepageTitle}`;
   };
 
-  const fullTitle = generateTitle(location.pathname, pageTitle);
+  const fullTitle = generateTitle(
+    location.pathname.replace('/rules', ''),
+    pageTitle
+  );
 
   const canonical = parentSiteUrl + (location.pathname || '');
 

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -5,6 +5,7 @@ import { useStaticQuery, graphql } from 'gatsby';
 import { Location } from '@reach/router';
 import schemaGenerator from '../../helpers/schemaGenerator';
 import { pathPrefix, homepageTitle } from '../../../site-config';
+import titles from '../../helpers/config/pageTitles';
 
 const Head = ({
   siteTitle,
@@ -19,14 +20,6 @@ const Head = ({
   location,
 }) => {
   const generateTitle = (path, pageTitle) => {
-    const titles = {
-      '/latest-rules/': 'Latest Rules',
-      '/user/': 'User Rules',
-      '/orphaned/': 'Orphaned Rules',
-      '/archived/': 'Archived Rules',
-      '/profile/': 'Profile',
-    };
-
     if (pageTitle) {
       return `${pageTitle} | ${siteTitle}`;
     }

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -18,18 +18,27 @@ const Head = ({
   imageUrl,
   location,
 }) => {
-  const isHomePage =
-    location.pathname === '/' || location.pathname === '/rules/';
+  const generateTitle = (path, pageTitle = '') => {
+    const titles = {
+      '/orphaned/': 'Orphaned Rules',
+      '/archived/': 'Archived Rules',
+      '/profile/': 'Profile',
+    };
 
-  const setFullTitle = () => {
-    return isHomePage
-      ? `${siteTitle} | ${pageTitle}`
-      : pageTitle
-        ? `${pageTitle} | ${siteTitle}`
-        : siteTitle;
+    if (pageTitle) {
+      return `${pageTitle} | ${siteTitle}`;
+    }
+
+    const titleFromPath = titles[path];
+    if (titleFromPath) {
+      return `${titleFromPath} | ${siteTitle}`;
+    }
+
+    return `${siteTitle} | ${homepageTitle}`;
   };
 
-  const pageTitleFull = setFullTitle();
+  const fullTitle = generateTitle(location.pathname, pageTitle);
+
   const canonical = parentSiteUrl + (location.pathname || '');
 
   return (
@@ -43,9 +52,9 @@ const Head = ({
       />
 
       <meta content={siteTitle} name="apple-mobile-web-app-title" />
-      <meta content={pageTitleFull} property="og:title" />
-      <meta content={pageTitleFull} name="twitter:title" />
-      <title>{pageTitleFull}</title>
+      <meta content={fullTitle} property="og:title" />
+      <meta content={fullTitle} name="twitter:title" />
+      <title>{fullTitle}</title>
 
       <meta content={seoDescription || siteDescription} name="description" />
       <meta
@@ -71,7 +80,7 @@ const Head = ({
       <meta content="summary_large_image" name="twitter:card" />
       <meta content={`@${social.twitter}`} name="twitter:site" />
       <meta content={`@${social.twitter}`} name="twitter:creator" />
-      <meta content={pageTitleFull} name="twitter:text:title" />
+      <meta content={fullTitle} name="twitter:text:title" />
       <meta content={canonical} property="og:url" />
       <meta content={canonical} name="twitter:url" />
       <link rel="canonical" href={canonical} />
@@ -193,7 +202,7 @@ const Head = ({
             siteUrl,
             pageTitle,
             siteTitle,
-            pageTitleFull,
+            pageTitleFull: fullTitle,
           })
         )}
       </script>

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -52,12 +52,7 @@ const Layout = ({
           }}
         >
           <div className="flex flex-col min-h-screen main-container">
-            <Head
-              pageTitle={
-                crumbLabel == 'SSW Rules' ? 'Latest Rules' : crumbLabel
-              }
-              seoDescription={seoDescription}
-            />
+            <Head pageTitle={crumbLabel} seoDescription={seoDescription} />
             <Header displayActions={displayActions} ruleUri={ruleUri} />
             <main className="flex-1">{children}</main>
           </div>

--- a/src/helpers/config/pageTitles.js
+++ b/src/helpers/config/pageTitles.js
@@ -1,9 +1,0 @@
-const titles = {
-  '/latest-rules/': 'Latest Rules',
-  '/user/': 'User Rules',
-  '/orphaned/': 'Orphaned Rules',
-  '/archived/': 'Archived Rules',
-  '/profile/': 'Profile',
-};
-
-export default titles;

--- a/src/helpers/config/pageTitles.js
+++ b/src/helpers/config/pageTitles.js
@@ -1,0 +1,9 @@
+const titles = {
+  '/latest-rules/': 'Latest Rules',
+  '/user/': 'User Rules',
+  '/orphaned/': 'Orphaned Rules',
+  '/archived/': 'Archived Rules',
+  '/profile/': 'Profile',
+};
+
+export default titles;

--- a/src/helpers/wrapPageElement.js
+++ b/src/helpers/wrapPageElement.js
@@ -2,7 +2,6 @@ import React from 'react';
 //import Transition from '../components/transition/transition.js';
 import PropTypes from 'prop-types';
 import Layout from '../components/layout/layout';
-import siteConfig from '../../site-config';
 
 const wrapPageElement = ({ element, props }) => {
   const markdown =
@@ -10,20 +9,7 @@ const wrapPageElement = ({ element, props }) => {
       ? props.data.markdownRemark
       : null;
 
-  const getTitleFromPath = (path) => {
-    const titles = {
-      '/': siteConfig.homepageTitle,
-      '/orphaned/': 'Orphaned Rules',
-      '/archived/': 'Archived Rules',
-      '/profile/': 'Profile',
-    };
-
-    return titles[path] || siteConfig.breadcrumbDefault;
-  };
-
-  const pageTitle = markdown
-    ? markdown.frontmatter.title
-    : getTitleFromPath(props.path);
+  const pageTitle = markdown ? markdown.frontmatter.title : '';
 
   return (
     //<Transition {...props}>


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1333 

This PR fixes the issue where the default `<title>` in the page source was incorrect for some pages.

![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/19f304f3-b71c-4ac3-87e6-918ee60a5b04)
**Figure: Orphaned Rule**

![image](https://github.com/SSWConsulting/SSW.Rules/assets/127192800/f20c3cdd-db7b-43ab-b272-dd79ca1f3b13)
**Figure: Homepage**

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
