### PR TITLE
🐛 Fix Auth Pop-Up When Refresh Token Expires

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -43,6 +43,7 @@ const Layout = ({
         cacheLocation="localstorage"
         scope={process.env.AUTH0_SCOPE}
         audience={process.env.AUTH0_DOMAIN}
+        useRefreshTokensFallback={true}
       >
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
         <div

--- a/src/components/signin/signin.js
+++ b/src/components/signin/signin.js
@@ -21,7 +21,7 @@ const SignIn = () => {
 
   useEffect(() => {
     isAuthenticated ? setUserOrg() : null;
-  });
+  }, []);
 
   const setUserOrg = async () => {
     isAuthenticated

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -21,6 +21,7 @@ export const useAuthService = () => {
       }
       return claims.__raw;
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.log('Failed to fetch id token', error);
     }
   };

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,8 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react';
 
 export const useAuthService = () => {
-  const { getIdTokenClaims, getAccessTokenSilently, loginWithRedirect } =
-    useAuth0();
+  const { getIdTokenClaims, getAccessTokenSilently } = useAuth0();
 
   const fetchIdToken = async () => {
     try {
@@ -22,17 +21,7 @@ export const useAuthService = () => {
       }
       return claims.__raw;
     } catch (error) {
-      if (window.confirm('Your session has expired. Please log in again')) {
-        const currentPage =
-          typeof window !== 'undefined'
-            ? window.location.pathname.split('/').pop()
-            : null;
-        await loginWithRedirect({
-          appState: {
-            targetUrl: currentPage,
-          },
-        });
-      }
+      console.log('Failed to fetch id token', error);
     }
   };
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to Email: SSW Rules has this auth pop up ⚠️

Changes:
- Removed alert and `loginWithRedirect`
- Log users out when both the refresh token and ID token have expired

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
