### PR TITLE
👷 CI/CD - Make commit history update  optional

### DIFF
--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - release/*
   workflow_dispatch:
+    inputs:
+      commit_data:
+        description: 'Generate commit data'
+        required: true
+        default: 'yes'
+        type: choice
+        options:
+          - yes
+          - no
 
 concurrency:
   group: production
@@ -17,6 +26,7 @@ jobs:
     with:
       branch_name: ${{ github.ref }}
       environment: production
+      commit_data: ${{ github.event.inputs.commit_data }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -8,7 +8,6 @@ on:
     inputs:
       should_generate_commit_data:
         description: 'Generate commit data'
-        required: true
         default: 'yes'
         type: choice
         options:

--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -6,7 +6,7 @@ on:
       - release/*
   workflow_dispatch:
     inputs:
-      commit_data:
+      should_generate_commit_data:
         description: 'Generate commit data'
         required: true
         default: 'yes'
@@ -26,7 +26,7 @@ jobs:
     with:
       branch_name: ${{ github.ref }}
       environment: production
-      commit_data: ${{ github.event.inputs.commit_data }}
+      should_generate_commit_data: ${{ github.event.inputs.should_generate_commit_data }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/build-deploy-staging.yml
+++ b/.github/workflows/build-deploy-staging.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      should_generate_commit_data:
+        description: 'Generate commit data'
+        default: 'yes'
+        type: choice
+        options:
+          - yes
+          - no
 
 concurrency:
   group: staging
@@ -17,6 +25,7 @@ jobs:
     with:
       branch_name: ${{ github.ref }}
       environment: staging
+      should_generate_commit_data: ${{ github.event.inputs.should_generate_commit_data }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -10,15 +10,16 @@ on:
         type: string
         required: true
         description: 'The environment to build for'
-      commit_data:
+      should_generate_commit_data:
         type: string
+        description: 'Generate commit data for rules history. You might want to skip this on large rules changes.'
         required: false
         default: 'yes'
 
 jobs:
   get-content-commit-data:
     name: Generate commit data
-    if: ${{ inputs.commit_data == 'yes' }}
+    if: ${{ inputs.should_generate_commit_data == 'yes' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -19,7 +19,6 @@ on:
 jobs:
   get-content-commit-data:
     name: Generate commit data
-    if: ${{ inputs.should_generate_commit_data == 'yes' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
@@ -49,6 +48,7 @@ jobs:
 
 
       - name: Get Rule History Commits
+        if: ${{ inputs.should_generate_commit_data == 'yes' }}
         shell: pwsh
         run: |
           ./SSW.Rules/build-scripts/update-rule-history.ps1 `
@@ -58,6 +58,7 @@ jobs:
             -UpdateHistorySyncCommitHashKey ${{ secrets.UPDATEHISTORYSYNCCOMMITHASHFUNCTIONKEY }}
   
       - name: Update Latest Rules
+        if: ${{ inputs.should_generate_commit_data == 'yes' }}
         shell: pwsh
         run: |
           ./SSW.Rules/build-scripts/update-latest-rules.ps1 `
@@ -74,6 +75,7 @@ jobs:
             -outputFileName ${{ github.workspace }}/static/history.json
 
       - name: Get History Commits of Each Contributor
+        if: ${{ inputs.should_generate_commit_data == 'yes' }}
         shell: pwsh
         run: |
           ./SSW.Rules/build-scripts/create-commits-history.ps1 `

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -54,7 +54,7 @@ jobs:
             -AzFunctionBaseUrl ${{ vars.AzFunctionBaseUrl }} `
             -GetHistorySyncCommitHashKey ${{ secrets.GETHISTORYSYNCCOMMITHASHFUNCTIONKEY }} `
             -UpdateRuleHistoryKey ${{ secrets.UPDATERULEHISTORYFUNCTIONKEY }} `
-            -UpdateHistorySyncCommitHashKey ${{ secrets.UPDATEHISTORYSYNCCOMMITHASHFUNCTIONKEY }}
+            -UpdateHistorySyncCommitHashKey ${{ secrets.UPDATEHISTORYSYNCCOMMITHASHFUNCTIONKEY }} `
             -SkipGenerateHistory ${{ inputs.should_generate_commit_data == 'yes' }}
   
       - name: Update Latest Rules

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -10,10 +10,15 @@ on:
         type: string
         required: true
         description: 'The environment to build for'
+      commit_data:
+        type: string
+        required: false
+        default: 'yes'
 
 jobs:
   get-content-commit-data:
     name: Generate commit data
+    if: ${{ inputs.commit_data == 'yes' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -48,7 +48,6 @@ jobs:
 
 
       - name: Get Rule History Commits
-        if: ${{ inputs.should_generate_commit_data == 'yes' }}
         shell: pwsh
         run: |
           ./SSW.Rules/build-scripts/update-rule-history.ps1 `
@@ -56,6 +55,7 @@ jobs:
             -GetHistorySyncCommitHashKey ${{ secrets.GETHISTORYSYNCCOMMITHASHFUNCTIONKEY }} `
             -UpdateRuleHistoryKey ${{ secrets.UPDATERULEHISTORYFUNCTIONKEY }} `
             -UpdateHistorySyncCommitHashKey ${{ secrets.UPDATEHISTORYSYNCCOMMITHASHFUNCTIONKEY }}
+            -SkipGenerateHistory ${{ inputs.should_generate_commit_data == 'yes' }}
   
       - name: Update Latest Rules
         if: ${{ inputs.should_generate_commit_data == 'yes' }}


### PR DESCRIPTION
Relates to #1367

Sometimes there are huge automated changes to lots of rules, we dont want these in the history.
This option allows them to be skipped.