### PR TITLE
🐛 Fix Updated Date bug

### DIFF
--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -4,7 +4,7 @@ param (
     [string]$UpdateRuleHistoryKey,
     [string]$UpdateHistorySyncCommitHashKey,
     [string]$endCommitHash = "HEAD",
-    [string]$ShouldGenerateHistory = $false
+    [string]$ShouldGenerateHistory = $true
     # Do this if your PR is giant 
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )
@@ -48,7 +48,7 @@ $historyArray | Foreach-Object {
         $commitSyncHash = $userDetails[1]
     }
 
-    if ($SkipGenerateHistory) {
+    if ($ShouldGenerateHistory) {
         $lastUpdated = $userDetails[2]
         $lastUpdatedBy = $userDetails[3]
         $lastUpdatedByEmail = $userDetails[4]
@@ -77,7 +77,7 @@ $historyArray | Foreach-Object {
 }
 
 
-if ($SkipGenerateHistory) {
+if ($ShouldGenerateHistory) {
     #Step 3: UpdateRuleHistory - Send History Patch to AzureFunction
     $historyFileContents = ConvertTo-Json $historyFileArray
     $Uri = $AzFunctionBaseUrl + '/api/UpdateRuleHistory'
@@ -96,7 +96,7 @@ if(![string]::IsNullOrWhiteSpace($commitSyncHash))
     $Result = Invoke-WebRequest -Uri $Uri -Method Post -Body $Body -Headers $Headers
 }
 
-if ($SkipGenerateHistory) {
+if ($ShouldGenerateHistory) {
     echo $historyFileContents
 }
 


### PR DESCRIPTION
`$SkipGenerateHistory` variable wasn't defined, and it was used in `update-rule-history.ps1` file to generate history under `true` condition. Replaced this variable with $ShouldGenerateHistory which is set `true` by default

<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->
The updated date data was incorrect on Latest Rules page

Relates to #1390

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
