### PR TITLE
♻️ Allow concurrent builds, but not deploys

### DIFF
--- a/.github/workflows/build-deploy-production.yml
+++ b/.github/workflows/build-deploy-production.yml
@@ -11,9 +11,6 @@ on:
         description: 'Generate commit data'
         default: true
 
-concurrency:
-  group: production
-
 jobs:
 
   build:
@@ -26,6 +23,9 @@ jobs:
     secrets: inherit
 
   deploy:
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
     needs:
       - build
     name: Deploy

--- a/.github/workflows/build-deploy-staging.yml
+++ b/.github/workflows/build-deploy-staging.yml
@@ -11,9 +11,6 @@ on:
         description: 'Generate commit data'
         default: true
 
-concurrency:
-  group: staging
-
 jobs:
 
   build:
@@ -26,6 +23,9 @@ jobs:
     secrets: inherit
 
   deploy:
+    concurrency:
+      group: staging-deploy
+      cancel-in-progress: false
     needs: build
     name: Deploy
     uses: ./.github/workflows/template-deploy.yml


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Allow builds to always run, then wait to deploy until the previous run is finished. This saves time as build takes ~10 minutes, which can be done by the time the previous run finishes deploying

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
