### PR TITLE
💄 Heading strong tag - Keep font width semibold

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -93,6 +93,7 @@ module.exports = {
         },
         'h2 strong, h3 strong, h4 strong, h5 strong, h6 strong': {
           color: theme('colors.ssw.red'),
+          fontWeight: theme('fontWeight.semibold'),
         },
       });
     }),


### PR DESCRIPTION
As per the email:
**From**: @bettybondoc 
**Sent**: Friday, August 2, 2024 9:14 AM
**To**: @jeoffreyfischer 
**Cc**: @jaydenalchin @tiagov8 
**Subject:** SSW.Rules - Fix emphasised heading format

**Description**
The new feature that turns text red when using a strong tag inside a heading is not working as expected.
It does also change the text font weight to bold.

**Expected behaviour**
We want the test font weight to remain semi-bold.

**Solution**
✅ This has been fixed - the text inside a strong tag is now semi-bold (see screenshot).

Relates to #1399

**Screenshot**
![image](https://github.com/user-attachments/assets/d02a8605-8578-47ef-821c-e53257d6a33d)
**Figure: Example of how strong tag looks in a heading**