### PR TITLE
Fixed boxes with icons for iOS + for 1 line sentences

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1063,6 +1063,7 @@ div.bad-example {
   
 .info, .china, .codeauditor {
   border: 1px solid #ccc;
+  min-height: 4.5rem;
 }
 
 .info > *, .china > *, .codeauditor > * {
@@ -1083,22 +1084,23 @@ div.bad-example {
 
 .info:before, .codeauditor:before, .china:before {
   margin-right: 1rem;
-  overlay: auto;
+  position: fixed;
 }
 
 .info:before, .codeauditor:before {
   line-height: initial;
   font-family: FontAwesome;
-  font-size: 2.5rem;
   @apply text-ssw-red; 
 }
   
 .info:before {
   content: "\f05a ";
+  font-size: 2.5rem;
 }
 
 .codeauditor:before {
   content: "\f121 ";
+  font-size: 2rem;
 }
 
 .china:before {


### PR DESCRIPTION
as per @adamcogan 's **RE: Expenses - Do you track your recurring expenses? | SSW.Rules**\
cc @jeoffreyfischer 

--

<img width="502" alt="Screenshot 2024-09-16 at 10 32 28 AM" src="https://github.com/user-attachments/assets/34b3a68a-520b-414e-89fb-fec114a11487">

**❌ Figure: Extra space on iOS**

<img width="280" alt="Screenshot 2024-09-16 at 10 33 06 AM" src="https://github.com/user-attachments/assets/8472994f-7c82-4a95-8780-624874cc2eac">

**❌ Figure: Lack of space if 1 line only**