### PR TITLE
Update style.css avoid odd spaces on lists inside boxes

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1074,7 +1074,7 @@ div.bad-example {
   padding-left: 5rem;
 }
   
-.greybox :first-child, .highlight :first-child, .info :first-child, .china :first-child, .codeauditor :first-child, .todo :first-child, blockquote :first-child {
+.greybox > :first-child, .highlight > :first-child, .info > :first-child, .china > :first-child, .codeauditor > :first-child, .todo > :first-child, blockquote > :first-child {
   margin-top:0;
 }
 


### PR DESCRIPTION
Fixes this:

<img width="764" alt="Screenshot 2024-09-16 at 9 02 20 PM" src="https://github.com/user-attachments/assets/3e8ee38d-9de4-458d-a17c-fde465dd26e3">

https://www.ssw.com.au/rules/craft-and-deliver-engaging-presentations/