### PR TITLE
Tina Migration - Fix staging environment 

### DIFF
--- a/.github/workflows/build-deploy-tina-migration.yml
+++ b/.github/workflows/build-deploy-tina-migration.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/template-build.yml
     with:
       branch_name: tina/main
-      environment: tinacms
+      environment: staging
       customStorageAccountNames: 'tina'
       should_generate_commit_data: ${{ github.event.inputs.should_generate_commit_data == 'true' }}
     secrets: inherit

--- a/.github/workflows/build-deploy-tina-migration.yml
+++ b/.github/workflows/build-deploy-tina-migration.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       branch_name: tina/main
       environment: staging
-      should_generate_commit_data: ${{ github.event.inputs.should_generate_commit_data == 'true' }}
+      should_generate_commit_data: ${{ 'false' }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/build-deploy-tina-migration.yml
+++ b/.github/workflows/build-deploy-tina-migration.yml
@@ -20,7 +20,6 @@ jobs:
     with:
       branch_name: tina/main
       environment: staging
-      customStorageAccountNames: 'tina'
       should_generate_commit_data: ${{ github.event.inputs.should_generate_commit_data == 'true' }}
     secrets: inherit
 
@@ -33,5 +32,5 @@ jobs:
     uses: ./.github/workflows/template-deploy.yml
     with:
       environment: staging
-      
+      storageAccountName: 'tina'
     secrets: inherit

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -10,10 +10,6 @@ on:
         type: string
         required: true
         description: 'The environment to build for'
-      customStorageAccountNames: 
-        type: string
-        required: false
-        description: 'Custom storage account names for the environment' 
       should_generate_commit_data:
         type: boolean
         description: 'Generate commit data for rules history. You might want to skip this on large rules changes.'


### PR DESCRIPTION
### Description 
This PR updates the staging environment for the tina migration to use the existing staging environment variables.

Because the blob storage account is already being named using a parameter in template-build action

Relates to #1506 


