### PR TITLE
💡 Added logic to remove whitespace from the line

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,7 +25,7 @@ let assetsManifest = {};
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions;
   if (node.internal.type === 'MarkdownRemark') {
-    // The issue is being tracked on gatsby side - https://github.com/gatsbyjs/gatsby/issues/39136
+    // TODO: Workaround - The issue is being tracked on the Gatsby side - https://github.com/gatsbyjs/gatsby/issues/39136
     const trimmedContent = node.internal.content
       .split('\n')
       .map((line) => (line.trim() === '' ? '' : line))

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,6 +25,13 @@ let assetsManifest = {};
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions;
   if (node.internal.type === 'MarkdownRemark') {
+    const trimmedContent = node.internal.content
+      .split('\n')
+      .map((line) => (line.trim() === '' ? '' : line))
+      .join('\n');
+
+    node.internal.content = trimmedContent;
+
     const slug = createFilePath({ node, getNode, basePath: '' });
     createNodeField({
       node,
@@ -33,6 +40,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     });
   }
 };
+
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
   const typeDefs = `

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -25,6 +25,7 @@ let assetsManifest = {};
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions;
   if (node.internal.type === 'MarkdownRemark') {
+    // The issue is being tracked on gatsby side - https://github.com/gatsbyjs/gatsby/issues/39136
     const trimmedContent = node.internal.content
       .split('\n')
       .map((line) => (line.trim() === '' ? '' : line))


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->
cc: @bradystroud @Calinator444 @tkapa @BrookJeynes 

Relates to #1448

Added logic to `gatsby-node.js` to remove whitespace from lines that contains only whitespace.
Then tested `yarn build` with new logic and without it.

For testing created `test-sample-content` branch in content repo, and added intentional whitespace to the rule.

![image](https://github.com/user-attachments/assets/e5ec5ea4-ea4a-4187-b64a-916879f99780)
**Figure: Line 67 contains a whitespace**

As result:
- ✅ build is successful with new logic
- ❌ build fails without new logic, and the error message was same that we have seen in recent workflow failures.

![image](https://github.com/user-attachments/assets/9add295d-8361-4488-bde4-70a5f856b6fd)
**Figure: Build fails without new logic**

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->
<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->


--- 
🤖 Copilot's summary

This pull request includes changes to the `gatsby-node.js` file to improve the handling of Markdown content and streamline the code.

Content handling improvements:

* [`gatsby-node.js`](diffhunk://#diff-a6f3904c41211be170d9b0eb87e49ea8d02d0fd5a7224d6772174b425dacf90fR28-R34): Added logic to trim empty lines from the Markdown content before processing. This ensures that unnecessary whitespace is removed, leading to cleaner content handling.

Codebase simplification:

* [`gatsby-node.js`](diffhunk://#diff-a6f3904c41211be170d9b0eb87e49ea8d02d0fd5a7224d6772174b425dacf90fR43): Added a new line after the `onCreateNode` function for better readability and separation of concerns.

