### PR TITLE
✨ TinaCMS | Configure Base Path - /admin

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -132,6 +132,7 @@ jobs:
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
           TINA_CLIENT_ID: ${{ secrets.TINA_CLIENT_ID }}
           TINA_TOKEN: ${{ secrets.TINA_TOKEN }}
+          TINA_BASE_PATH: ${{ vars.TINA_BASE_PATH }}
 
       - name: Rename env file
         run: |

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   localContentPath,
 
   build: {
+    basePath: 'rules',
     outputFolder: 'admin',
     publicFolder: 'static',
   },

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -7,6 +7,7 @@ const branch = 'tina/sample-content';
 const localContentPath = process.env.LOCAL_CONTENT_RELATIVE_PATH ?? undefined;
 const clientId = process.env.TINA_CLIENT_ID;
 const token = process.env.TINA_TOKEN;
+const basePath = process.env.TINA_BASE_PATH ?? undefined;
 
 export default defineConfig({
   // Required as per https://tina.io/docs/frameworks/gatsby/#workaround-for-graphql-mismatch-issue
@@ -19,7 +20,7 @@ export default defineConfig({
   localContentPath,
 
   build: {
-    basePath: 'rules',
+    basePath,
     outputFolder: 'admin',
     publicFolder: 'static',
   },


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #1461 
Relates to #1465 

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

Updates the basePath for Tina so that we can grab the proper resources when hitting /admin.

Make basePath configurable in .env for the future.

![image](https://github.com/user-attachments/assets/b5639c47-6c88-4ecc-86b1-392f49edd281)
_**Figure: /admin is now available on the staging server**_

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
