### PR TITLE
♻️ Renamed storage account param name to match with the bicep param

### DIFF
--- a/.github/workflows/template-deploy.yml
+++ b/.github/workflows/template-deploy.yml
@@ -52,7 +52,7 @@ jobs:
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
             --template-file infra/main.bicep \
             --parameters \
-              storageAccountName=${{ inputs.storageAccountName }} \
+              customStorageAccountNames=${{ inputs.storageAccountName }} \
               environmentName=${{ inputs.environment }} \
             --mode Incremental
       


### PR DESCRIPTION
cc: @tkapa @bradystroud 

After creating a new `release/141` from main, the `Deploy Infra` job was failing due to recent changes into main to support tina migration. 
This pull request includes a small change to the `.github/workflows/template-deploy.yml` file.
**Note:** I will be deleting new created release branch for now.

* `.github/workflows/template-deploy.yml`: Renamed `storageAccountName` to `customStorageAccountNames` in the deployment script so it matches with the `main.bicep` params list.

![image](https://github.com/user-attachments/assets/00c7530b-5b0c-486b-9583-f0d8d84db338)
**Figure: Deploy Infra failing - https://github.com/SSWConsulting/SSW.Rules/actions/runs/11231860515/job/31223250760**