### PR TITLE
🔁 App Insights - Added filter to filter out google analytics with 0 code

### DIFF
--- a/src/hooks/useAppInsights.js
+++ b/src/hooks/useAppInsights.js
@@ -21,11 +21,13 @@ export default function useAppInsights() {
     ai.loadAppInsights();
     ai.addTelemetryInitializer((item) => {
       item.tags['ai.cloud.role'] = 'SSW.Rules-StaticClientPage';
+
       if (
         item.baseData?.target?.includes('analytics.google.com') &&
         item.baseData?.responseCode == 0
       ) {
-        return false; // Exclude Google Analytics logs with responseCode=0
+        // mark these as successful requests as per this comment - https://github.com/SSWConsulting/SSW.Rules/issues/1589#issuecomment-2437107468
+        item.baseData.success = true;
       }
     });
   }

--- a/src/hooks/useAppInsights.js
+++ b/src/hooks/useAppInsights.js
@@ -21,6 +21,12 @@ export default function useAppInsights() {
     ai.loadAppInsights();
     ai.addTelemetryInitializer((item) => {
       item.tags['ai.cloud.role'] = 'SSW.Rules-StaticClientPage';
+      if (
+        item.baseData?.target?.includes('analytics.google.com') &&
+        item.baseData?.responseCode == 0
+      ) {
+        return false; // Exclude Google Analytics logs with responseCode=0
+      }
     });
   }
 


### PR DESCRIPTION
Relates to #1589

This pull request includes a small change to the `useAppInsights` hook. The change ensures that Google Analytics logs with a response code of 0 are marked as success. The reason I explained in this comment https://github.com/SSWConsulting/SSW.Rules/issues/1589#issuecomment-2437107468
