### PR TITLE
Add nosnippet rule categories

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,19 +1,19 @@
-import { Link, useStaticQuery, graphql } from 'gatsby';
 import {
   faArchive,
-  faPause,
   faBolt,
   faFrownOpen,
+  faPause,
 } from '@fortawesome/free-solid-svg-icons';
+import { graphql, Link, useStaticQuery } from 'gatsby';
 
-import Breadcrumb from '../components/breadcrumb/breadcrumb';
+import { config } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Breadcrumb from '../components/breadcrumb/breadcrumb';
+import SearchBar from '../components/search-bar/search-bar';
 import SideBar from '../components/side-bar/side-bar';
 import TopCategory from '../components/top-category/top-category';
-import { config } from '@fortawesome/fontawesome-svg-core';
-import SearchBar from '../components/search-bar/search-bar';
 
 config.autoAddCss = false;
 
@@ -52,7 +52,7 @@ const Index = ({ data, location }) => {
                   );
                   if (cat) {
                     return (
-                      <section className="mb-5 relative" key={i}>
+                      <section data-nosnippet className="mb-5 relative" key={i}>
                         <TopCategory
                           topcategory={cat}
                           categories={data.categories}

--- a/src/pages/orphaned.js
+++ b/src/pages/orphaned.js
@@ -1,23 +1,22 @@
-import React, { useRef, useState, useEffect } from 'react';
-import { useStaticQuery, graphql } from 'gatsby';
-import PropTypes from 'prop-types';
 import { config } from '@fortawesome/fontawesome-svg-core';
-import Breadcrumb from '../components/breadcrumb/breadcrumb';
-import Tooltip from '../components/tooltip/tooltip';
-import RadioButton from '../components/radio-button/radio-button';
-import { Link } from 'gatsby';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import {
   faArrowCircleRight,
-  faPencilAlt,
-  faExclamationTriangle,
-  faQuoteLeft,
-  faFileLines,
   faBook,
+  faExclamationTriangle,
+  faFileLines,
+  faPencilAlt,
+  faQuoteLeft,
 } from '@fortawesome/free-solid-svg-icons';
-import Bookmark from '../components/bookmark/bookmark';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { graphql, Link, useStaticQuery } from 'gatsby';
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef, useState } from 'react';
 import { pathPrefix } from '../../site-config';
+import Bookmark from '../components/bookmark/bookmark';
+import Breadcrumb from '../components/breadcrumb/breadcrumb';
+import RadioButton from '../components/radio-button/radio-button';
+import Tooltip from '../components/tooltip/tooltip';
 import useAppInsights from '../hooks/useAppInsights';
 
 config.autoAddCss = false;
@@ -78,7 +77,7 @@ const Orphaned = ({ data }) => {
       <div className="w-full">
         <div className="rule-category rounded">
           <section className="mb-20 rounded pb-2">
-            <div className="cat-title-grid-container">
+            <div className="cat-title-grid-container" data-nosnippet>
               <h1 className="text-ssw-black font-medium text-3xl">
                 Orphaned Rules
                 <span className="rule-count">

--- a/src/pages/orphaned.js
+++ b/src/pages/orphaned.js
@@ -144,7 +144,7 @@ const Orphaned = ({ data }) => {
                 />
               </div>
             )}
-            <div className="category-rule">
+            <div data-nosnippet className="category-rule">
               <ol className="rule-number">
                 {rules.map((rule, i) => {
                   if (!rule) {


### PR DESCRIPTION
### Description 

Google was appending rule lists on `/rules` and `/rules/orphaned` to the snippets for those pages so I've added the data-nosnippet header to ensure the content of these lists will be ignored


For more information about the data-nosnippet attribute see this documentation
https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr




### Screenshots

##### ❌Before

![image](https://github.com/user-attachments/assets/32727ae6-2598-45cc-bb5f-dedce4e5024d)
**Figure**: **Rule list being used for snippet on rules home page google search result**


![image](https://github.com/user-attachments/assets/73a82f72-2bf3-454e-83df-600e2d15f508)

**Figure** **rule list being used for snippet on orphaned page google search result**



###### ✅After

![image](https://github.com/user-attachments/assets/9dea2b73-426d-46c1-a47a-343fb099ec54)
**Figure**: **Rules category box  with data-nosnippet attribute added**

![image](https://github.com/user-attachments/assets/338e9757-ea93-4842-9e07-53f35cc3cad3)
**Figure**: **Orphaned Rules list has data-nosnippet attirbute added**