### PR TITLE
♻️ Changed the comment box position from bottom to top

### DIFF
--- a/src/components/discussion/discussion.js
+++ b/src/components/discussion/discussion.js
@@ -16,7 +16,7 @@ const Discussion = (props) => {
         term={props.ruleGuid}
         reactionsEnabled="1"
         emitMetadata="0"
-        inputPosition="bottom"
+        inputPosition="top"
         theme="light"
         lang="en"
         loading="lazy"


### PR DESCRIPTION
Relates to #1567

Changed the comment box position to the top, so users don't need scroll all the way down to add a comment when the discussion has many comments

![image](https://github.com/user-attachments/assets/c11ed518-8981-40b3-8eee-c977628ddedc)
**Figure: Comment box is placed on top of comments**
