### PR TITLE
🔍 Added unique meta description for home page

### DIFF
--- a/site-config.js
+++ b/site-config.js
@@ -12,6 +12,7 @@ module.exports = {
   siteTitle: `SSW.Rules`,
   siteTitleShort: `SSW.Rules`,
   siteDescription: `Secret Ingredients to Quality Software | SSW Rules provides best practices for developing secure, reliable, and efficient .NET, Azure, CRM, Angular, React, Dynamics, and AI applications. Learn more today!`,
+  homePageDescription: `Explore SSW Rules – a trusted library of best practices for software development and project management designed to foster growth and boost productivity!`,
   siteUrl: `https://www.ssw.com.au/rules`,
   // Relative URL to website home
   siteUrlRelative: `/`,

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -82,6 +82,9 @@ Layout.propTypes = {
   crumbLocation: PropTypes.object,
   crumbLabel: PropTypes.string,
   seoDescription: PropTypes.string,
+  location: {
+    href: PropTypes.string,
+  },
 };
 
 function LayoutWithQuery(props) {

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -21,7 +21,7 @@ const Layout = ({
 }) => {
   const isHomePage =
     location?.href &&
-    location?.href.match(/https:\/\/www\.ssw\.com\.au\/rules\/{0,1}/);
+    location?.href.match(/^https:\/\/www\.ssw\.com\.au\/rules\/{0,1}$/);
   const description = isHomePage
     ? data?.site?.siteMetadata.homePageDescription
     : seoDescription;

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -1,22 +1,30 @@
-import React, { useRef, useState } from 'react';
+import { Auth0Provider } from '@auth0/auth0-react';
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+import { graphql, navigate, useStaticQuery } from 'gatsby';
 import PropTypes from 'prop-types';
-import { useStaticQuery, graphql, navigate } from 'gatsby';
+import React, { useRef, useState } from 'react';
+import '../../style.css';
+import Footer from '../footer/footer';
 import Head from '../head/head';
 import Header from '../header/header';
-import Footer from '../footer/footer';
-import '../../style.css';
-import { config } from '@fortawesome/fontawesome-svg-core';
-import { Auth0Provider } from '@auth0/auth0-react';
-import '@fortawesome/fontawesome-svg-core/styles.css';
 
 config.autoAddCss = false;
 const Layout = ({
+  data,
   children,
   displayActions,
   ruleUri,
   crumbLabel,
   seoDescription,
+  location,
 }) => {
+  const isHomePage =
+    location?.href &&
+    location?.href.match(/https:\/\/www\.ssw\.com\.au\/rules\/{0,1}/);
+  const description = isHomePage
+    ? data?.site?.siteMetadata.homePageDescription
+    : seoDescription;
   const node = useRef();
   const [isMenuOpened, setIsMenuOpened] = useState(false);
 
@@ -54,7 +62,7 @@ const Layout = ({
           }}
         >
           <div className="flex flex-col min-h-screen main-container">
-            <Head pageTitle={crumbLabel} seoDescription={seoDescription} />
+            <Head pageTitle={crumbLabel} seoDescription={description} />
             <Header displayActions={displayActions} ruleUri={ruleUri} />
             <main className="flex-1">{children}</main>
           </div>
@@ -82,6 +90,7 @@ function LayoutWithQuery(props) {
       site {
         siteMetadata {
           siteTitle
+          homePageDescription
         }
       }
     }


### PR DESCRIPTION
### Description
I've added a meta description to the home page. Since the meta-data gets injected at build time I needed to modify the Layout component with custom logic to update the home page meta description based on the route. It also doesn't appear to be possible to pass the page query data to gatsby-browser.js without opting the page out of static rendering.

~~Also every time I solve a problem using regex pattern a puppy somewhere in the world passes away~~

#### Note 
I've had the new meta-description test passed by Stef
