### PR TITLE
♻️ Inter Font - Added preload to avoid FOUT issues

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,5 @@
 import wrapPageElementWithTransition from './src/helpers/wrapPageElement.js';
-import '@fontsource/inter';
+import '@fontsource-variable/inter';
 
 require('gatsby-remark-vscode/styles.css');
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,21 @@
+/* eslint-disable react/react-in-jsx-scope */
+import * as React from 'react';
 import wrapPageElementWithTransition from './src/helpers/wrapPageElement.js';
+import '@fontsource-variable/inter';
+import interWoff2 from '@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url';
+
+export const onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href={interWoff2}
+      crossOrigin="anonymous"
+      key="interPreload"
+    />,
+  ]);
+};
 
 // Page Transitions
 export const wrapPageElement = wrapPageElementWithTransition;

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
 import * as React from 'react';
 import wrapPageElementWithTransition from './src/helpers/wrapPageElement.js';
 import '@fontsource-variable/inter';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.2.4",
-    "@fontsource/inter": "^5.1.0",
+    "@fontsource-variable/inter": "^5.1.0",
     "@giscus/react": "^3.0.0",
     "@microsoft/applicationinsights-web": "^3.3.3",
     "@raae/gatsby-remark-oembed": "^0.3.3",

--- a/src/style.css
+++ b/src/style.css
@@ -39,7 +39,7 @@
 }
  
 html {
-  font-family: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif
+  font-family: "Inter Variable", sans-serif
 }
 
 body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,10 +2708,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fontsource/inter@npm:^5.1.0":
+"@fontsource-variable/inter@npm:^5.1.0":
   version: 5.1.0
-  resolution: "@fontsource/inter@npm:5.1.0"
-  checksum: 48c740b8a311908ca9527bf598e759bdfad6429f730450cc4904877915537e857a322db3ff7ade0bf731a3853ab34e611638d560529774a7e94ca2237735c86b
+  resolution: "@fontsource-variable/inter@npm:5.1.0"
+  checksum: 6b46019c71380f6e18427b4b19468a9a656609fcf613b8472f7b928ec1bc6f13b03d1dd0bb9536cd168a53e58c009465e2245cd87ef57f9925a07d2306bd8f58
   languageName: node
   linkType: hard
 
@@ -6791,7 +6791,7 @@ __metadata:
     "@auth0/auth0-react": "npm:^2.2.4"
     "@babel/eslint-parser": "npm:^7.25.1"
     "@babel/preset-react": "npm:^7.24.7"
-    "@fontsource/inter": "npm:^5.1.0"
+    "@fontsource-variable/inter": "npm:^5.1.0"
     "@fortawesome/fontawesome-svg-core": "npm:^6.6.0"
     "@fortawesome/free-brands-svg-icons": "npm:^6.6.0"
     "@fortawesome/free-solid-svg-icons": "npm:^6.6.0"


### PR DESCRIPTION
Relates to #1600

This pull request includes updates to replace the `@fontsource/inter` package with `@fontsource-variable/inter`.

`@fontsource-variable/inter` version enables to use single font file that contains multiple variations of the same font, such as different weights, widths, and styles. Read more at docs - https://fontsource.org/docs/getting-started/variable

Also added `preload` option to improve performance by loading font file before they are acquired.
https://fontsource.org/docs/getting-started/preload
https://web.dev/articles/codelab-preload-web-fonts

![image](https://github.com/user-attachments/assets/1fd69a44-70ec-49c4-979a-241b5c8c4083)
**Figure: preload link was added to header**

Font updates:

* `gatsby-browser.js`: Replaced `@fontsource/inter` with `@fontsource-variable/inter`.
* `gatsby-ssr.js`: Added import for `@fontsource-variable/inter` and included a preload link for the `woff2` (file that contains all font variations) font file in the `onRenderBody` function.
* `package.json`: Updated the dependency from `@fontsource/inter` to `@fontsource-variable/inter`.
* `src/style.css`: Changed the `font-family` to use "Inter Variable" instead of "Inter".

When refreshing the page in local, it becomes all white then the page is displayed (in production not like this). But the correct font is rendered. So I wasn't able to really test the current [FOUT](https://fonts.google.com/knowledge/glossary/fout) issue in local

![47B84483-B985-4096-A3D4-C14430C4451E](https://github.com/user-attachments/assets/ecfa3ca2-32fc-486e-a432-2effeaa55e29)
**Figure: Correct font is rendered in local**

