### PR TITLE
Update footer.js - GitHub section - added classes for a better view on mobile

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -20,7 +20,7 @@ const Footer = () => {
   return (
     <>
       <div className="py-2 text-center bg-grey-translucent text-sm">
-        <section className="main-container flex items-center justify-center">
+        <section className="main-container flex items-center justify-center gap-4	flex-wrap">
           <span className="mr-2">
             We <FontAwesomeIcon icon={faHeart} className="text-ssw-red" /> open
             source. Loving SSW Rules?{' '}


### PR DESCRIPTION
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1639

should change from

<img width="479" alt="Screenshot 2024-11-26 at 10 31 49 AM" src="https://github.com/user-attachments/assets/31cdf187-108b-4246-8c04-75318c3739ff">

to

<img width="511" alt="Screenshot 2024-11-26 at 10 31 37 AM" src="https://github.com/user-attachments/assets/b88a1e53-8680-4483-8f51-a8cd67944bc3">





