### PR TITLE
Build action - change timeout from 1hr to 30min

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -166,7 +166,7 @@ jobs:
         run: yarn build
         env:
           GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
-        timeout-minutes: 60
+        timeout-minutes: 30
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ To update specific markdown components, follow these steps:
    - Open your local instance of SSW.Rules, usually in VS Code
    - Build the project using the following commands: `yarn clean` and then `yarn dev`
    - Open your local instance in your browser and navigate to the edited rule to see your changes
+
+### Gatsby Build Timeout
+
+The Gatsby build step in GitHub Actions has a 30-minute timeout to prevent it from running indefinitely. This is due to intermittent issues with external dependencies.
+
+For more details on the Gatsby build issue, refer to the [Gatsby issue](https://github.com/gatsbyjs/gatsby/issues/38989).


### PR DESCRIPTION
Looking at the history it never goes longer than 30 min. This reduces wasted action minutes but doesn't fix the problem - we have no idea why its failing 

https://github.com/SSWConsulting/SSW.Rules/issues/1337