### PR TITLE
Readme - document Gatsby build timeout 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ To update specific markdown components, follow these steps:
    - Open your local instance of SSW.Rules, usually in VS Code
    - Build the project using the following commands: `yarn clean` and then `yarn dev`
    - Open your local instance in your browser and navigate to the edited rule to see your changes
+
+### Gatsby Build Timeout
+
+The Gatsby build step in GitHub Actions has a 30-minute timeout to prevent it from running indefinitely. This is due to intermittent issues with external dependencies.
+
+For more details on the Gatsby build issue, refer to the [Gatsby issue](https://github.com/gatsbyjs/gatsby/issues/38989).


### PR DESCRIPTION
Related to #1337

Add documentation for Gatsby build timeout in `README.md`.

* Add a section to document the 30-minute timeout for the Gatsby build step.
* Include a note about the intermittent issues with external dependencies causing delays.
* Provide a link to the Gatsby issue created for tracking the problem.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SSWConsulting/SSW.Rules/pull/1654?shareId=974a7d8f-4121-4298-81ad-d6c02b0ae854).