### PR TITLE
Fixed acknowledged rules

### DIFF
--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -204,7 +204,11 @@ const UserRules = ({ data, location }) => {
 
   const getRulePath = (path) => {
     const lastSlashIndex = path.lastIndexOf('/');
-    if (!path.includes('categories') && path.lastIndexOf('/') !== -1) {
+    if (
+      path.includes('.md') &&
+      !path.includes('categories') &&
+      path.lastIndexOf('/') !== -1
+    ) {
       return path.substring(0, lastSlashIndex + 1);
     } else {
       return path;

--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -202,14 +202,14 @@ const UserRules = ({ data, location }) => {
     return extractedFiles;
   };
 
-  function getRulePath(path) {
+  const getRulePath = (path) => {
     const lastSlashIndex = path.lastIndexOf('/');
     if (!path.includes('categories') && path.lastIndexOf('/') !== -1) {
       return path.substring(0, lastSlashIndex + 1);
     } else {
       return path;
     }
-  }
+  };
 
   const filterUniqueRules = (extractedFiles) => {
     const filteredRules = extractedFiles

--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -207,7 +207,7 @@ const UserRules = ({ data, location }) => {
     if (
       path.includes('.md') &&
       !path.includes('categories') &&
-      path.lastIndexOf('/') !== -1
+      lastSlashIndex !== -1
     ) {
       return path.substring(0, lastSlashIndex + 1);
     } else {

--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -191,7 +191,7 @@ const UserRules = ({ data, location }) => {
         extractedFiles.push({
           file: {
             node: {
-              path: path.path.replace('rule.md', ''),
+              path: getRulePath(path.path),
               lastUpdated: updatedTime,
             },
           },
@@ -201,6 +201,15 @@ const UserRules = ({ data, location }) => {
 
     return extractedFiles;
   };
+
+  function getRulePath(path) {
+    const lastSlashIndex = path.lastIndexOf('/');
+    if (!path.includes('categories') && path.lastIndexOf('/') !== -1) {
+      return path.substring(0, lastSlashIndex + 1);
+    } else {
+      return path;
+    }
+  }
 
   const filterUniqueRules = (extractedFiles) => {
     const filteredRules = extractedFiles


### PR DESCRIPTION
cc: @Freego1783 

Email: "Re: SSW Rules - Searching by author - Nothing showing for me"

Rules weren't being displayed for Hugo on search page. The reason is when rule is created, the markdown file name was "rules.md", and then it was changed to "rule.md". Current logic for that page only removes "rule.md" from path and it doesn't work for "rules.md".

So I've created function that retrieves path without filename.

![image](https://github.com/user-attachments/assets/139a8a62-b515-40fa-91ff-638e3cb5878f)
**Figure: Hugo's rule is displayed on Acknowledged section**
