### PR TITLE
CI/CD - Fix builds from big content change

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,4 +14,5 @@ jobs:
     with:
       branch_name: ${{ github.ref }}
       environment: staging
+      should_generate_commit_data: false
     secrets: inherit

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -21,10 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - name: Log should_generate_commit_data
-        run: |
-          echo "should_generate_commit_data: ${{ inputs.should_generate_commit_data }}"
-
       - uses: actions/checkout@v4
         name: Checkout SSW.Rules
         with:

--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -13,8 +13,7 @@ on:
       should_generate_commit_data:
         type: boolean
         description: 'Generate commit data for rules history. You might want to skip this on large rules changes.'
-        required: false
-        default: true
+        required: true
 
 jobs:
   get-content-commit-data:
@@ -22,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
+      - name: Log should_generate_commit_data
+        run: |
+          echo "should_generate_commit_data: ${{ inputs.should_generate_commit_data }}"
 
       - uses: actions/checkout@v4
         name: Checkout SSW.Rules

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -9,7 +9,7 @@ param (
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )
 
-$ShouldGenerateHistory = $ShouldGenerateHistory -ieq "true"
+$ShouldGenerateHistory = [bool]($ShouldGenerateHistory -ieq "true")
 
 Write-Output "ShouldGenerateHistory raw value: '$ShouldGenerateHistory'"
 Write-Output "ShouldGenerateHistory type: $($ShouldGenerateHistory.GetType().Name)"

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -4,12 +4,15 @@ param (
     [string]$UpdateRuleHistoryKey,
     [string]$UpdateHistorySyncCommitHashKey,
     [string]$endCommitHash = "HEAD",
-    [bool]$ShouldGenerateHistory = $true
+    [string]$ShouldGenerateHistory = "true"
     # Do this if your PR is giant 
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )
 
-$ShouldGenerateHistory = [System.Convert]::ToBoolean($ShouldGenerateHistory)
+$ShouldGenerateHistory = $ShouldGenerateHistory -ieq "true"
+
+Write-Output "ShouldGenerateHistory raw value: '$ShouldGenerateHistory'"
+Write-Output "ShouldGenerateHistory type: $($ShouldGenerateHistory.GetType().Name)"
 
 if ($ShouldGenerateHistory) {
     Write-Output "Generating history"

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -9,10 +9,12 @@ param (
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )
 
-if ($ShouldGenerateHistory -eq $false) {
-    Write-Output "Skipping history generation"
-} else {
+$ShouldGenerateHistory = [System.Convert]::ToBoolean($ShouldGenerateHistory)
+
+if ($ShouldGenerateHistory) {
     Write-Output "Generating history"
+} else {
+    Write-Output "Skipping history generation"
 }
 
 
@@ -51,6 +53,7 @@ $historyArray | Foreach-Object {
     }
 
     if ($ShouldGenerateHistory) {
+        Write-Output "Processing commit $userDetails[1]"
         $lastUpdated = $userDetails[2]
         $lastUpdatedBy = $userDetails[3]
         $lastUpdatedByEmail = $userDetails[4]
@@ -132,7 +135,7 @@ if(![string]::IsNullOrWhiteSpace($commitSyncHash))
 }
 
 if ($ShouldGenerateHistory) {
-    echo $historyFileContents
+    Write-Output $historyFileContents
 }
 
-echo $commitSyncHash
+Write-Output $commitSyncHash

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -4,17 +4,13 @@ param (
     [string]$UpdateRuleHistoryKey,
     [string]$UpdateHistorySyncCommitHashKey,
     [string]$endCommitHash = "HEAD",
-    [string]$ShouldGenerateHistory = "true"  # Accepts string input
+    [string]$ShouldGenerateHistoryString = "true"  # Accepts string input
     # Do this if your PR is giant 
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )
 
 # Create a new boolean variable from the string input
-$IsHistoryGenerationEnabled = [string]::Equals($ShouldGenerateHistory, "true", [System.StringComparison]::OrdinalIgnoreCase)
-
-Write-Output "ShouldGenerateHistory raw value: '$ShouldGenerateHistory'"
-Write-Output "IsHistoryGenerationEnabled value: '$IsHistoryGenerationEnabled'"
-Write-Output "IsHistoryGenerationEnabled type: $($IsHistoryGenerationEnabled.GetType().Name)"
+$IsHistoryGenerationEnabled = [string]::Equals($ShouldGenerateHistoryString, "true", [System.StringComparison]::OrdinalIgnoreCase)
 
 if ($IsHistoryGenerationEnabled) {
     Write-Output "Generating history"

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -4,17 +4,19 @@ param (
     [string]$UpdateRuleHistoryKey,
     [string]$UpdateHistorySyncCommitHashKey,
     [string]$endCommitHash = "HEAD",
-    [string]$ShouldGenerateHistory = "true"
+    [string]$ShouldGenerateHistory = "true"  # Accepts string input
     # Do this if your PR is giant 
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )
 
-$ShouldGenerateHistory = [bool]($ShouldGenerateHistory -ieq "true")
+# Create a new boolean variable from the string input
+$IsHistoryGenerationEnabled = [string]::Equals($ShouldGenerateHistory, "true", [System.StringComparison]::OrdinalIgnoreCase)
 
 Write-Output "ShouldGenerateHistory raw value: '$ShouldGenerateHistory'"
-Write-Output "ShouldGenerateHistory type: $($ShouldGenerateHistory.GetType().Name)"
+Write-Output "IsHistoryGenerationEnabled value: '$IsHistoryGenerationEnabled'"
+Write-Output "IsHistoryGenerationEnabled type: $($IsHistoryGenerationEnabled.GetType().Name)"
 
-if ($ShouldGenerateHistory) {
+if ($IsHistoryGenerationEnabled) {
     Write-Output "Generating history"
 } else {
     Write-Output "Skipping history generation"
@@ -55,7 +57,7 @@ $historyArray | Foreach-Object {
         $commitSyncHash = $userDetails[1]
     }
 
-    if ($ShouldGenerateHistory) {
+    if ($IsHistoryGenerationEnabled) {
         Write-Output "Processing commit $userDetails[1]"
         $lastUpdated = $userDetails[2]
         $lastUpdatedBy = $userDetails[3]
@@ -118,7 +120,7 @@ $historyArray | Foreach-Object {
 }
 
 
-if ($ShouldGenerateHistory) {
+if ($IsHistoryGenerationEnabled) {
     #Step 3: UpdateRuleHistory - Send History Patch to AzureFunction
     $historyFileContents = ConvertTo-Json $historyFileArray
     $Uri = $AzFunctionBaseUrl + '/api/UpdateRuleHistory'
@@ -137,7 +139,7 @@ if(![string]::IsNullOrWhiteSpace($commitSyncHash))
     $Result = Invoke-WebRequest -Uri $Uri -Method Post -Body $Body -Headers $Headers
 }
 
-if ($ShouldGenerateHistory) {
+if ($IsHistoryGenerationEnabled) {
     Write-Output $historyFileContents
 }
 

--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -4,7 +4,7 @@ param (
     [string]$UpdateRuleHistoryKey,
     [string]$UpdateHistorySyncCommitHashKey,
     [string]$endCommitHash = "HEAD",
-    [string]$ShouldGenerateHistory = $true
+    [bool]$ShouldGenerateHistory = $true
     # Do this if your PR is giant 
     # https://github.com/SSWConsulting/SSW.Rules/issues/1367
 )


### PR DESCRIPTION
I merged the very large PR into the content repo and that broke the history generation scripts. They are supposed to skip giant PRs but the skin functionally wasn't working, so I fixed it in this PR.

https://github.com/SSWConsulting/SSW.Rules.Content/pull/9882