### PR TITLE
Added missing query field that required to get data

### DIFF
--- a/src/pages/user/index.js
+++ b/src/pages/user/index.js
@@ -355,6 +355,7 @@ function UserRulesWithQuery(props) {
         nodes {
           fullName
           slug
+          gitHubUrl
         }
       }
     }


### PR DESCRIPTION
Relates to
#1652 
#1361 

Added missing `githubUrl` field to query.
