### PR TITLE
We are getting a ton of hydration mismatches. Moving DateTime calcs to react useEffects

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -1,3 +1,4 @@
+import React, { useState, useEffect } from 'react';
 import {
   faFacebook,
   faInstagram,
@@ -10,13 +11,22 @@ import { faHeart } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import moment from 'moment';
 import preval from 'preval.macro';
-import React from 'react';
 import GitHubButton from 'react-github-btn';
 import { pathPrefix } from '../../../site-config';
 
 const buildTimestamp = preval`module.exports = new Date().getTime();`;
+const buildYear = preval`module.exports = new Date().getFullYear();`;
 
 const Footer = () => {
+  const [relativeDeployTime, setRelativeDeployTime] = useState('...');
+
+  useEffect(() => {
+    const update = () => setRelativeDeployTime(getLastDeployTime());
+    update();
+    const id = setInterval(update, 60000);
+    return () => clearInterval(id);
+  }, []);
+  
   return (
     <>
       <div className="p-4 text-center bg-grey-translucent text-sm">
@@ -62,7 +72,7 @@ const Footer = () => {
           <div className="xl:mx-6">
             <div className="mx-6 flex flex-col-reverse md:flex-row justify-between align-middle leading-6">
               <div className="py-2">
-                &copy; 1990-{new Date().getFullYear()} SSW. All rights reserved.
+                &copy; 1990-{buildYear} SSW. All rights reserved.
               </div>
               <div className="w-full md:w-3/6 md:text-right py-2">
                 <a
@@ -154,7 +164,7 @@ const Footer = () => {
                 >
                   CONSTANT CONTINUOUS DEPLOYMENT
                 </a>
-                . Last deployed {getLastDeployTime()} ago (Build #{' '}
+                . Last deployed <span suppressHydrationWarning>{relativeDeployTime}</span> ago (Build #{' '}
                 <a
                   className="footer-link"
                   href={

--- a/src/components/latest-rules-content/latestRulesContent.js
+++ b/src/components/latest-rules-content/latestRulesContent.js
@@ -3,7 +3,7 @@ import { bool, func, object, objectOf, string } from 'prop-types';
 import { FilterOptions } from '../filter/filter';
 import Heading from '../heading/heading';
 import { Link, navigate } from 'gatsby';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import locale from 'date-fns/locale/en-AU';
 import { sanitizeName } from '../../helpers/sanitizeName';
@@ -47,27 +47,38 @@ const LatestRulesContent = ({
     return result + ' ago';
   };
 
-  const FormatDate = ({ item }) => (
-    <span className="block text-light-grey text-right">
-      <FontAwesomeIcon icon={faClock} size="sm" className="mr-1" />
+  const FormatDate = ({ item }) => {
+    const [relative, setRelative] = useState('');
+    
+    useEffect(() => {
+      const compute = () =>
+        filteredItems.filter === FilterOptions.RecentlyUpdated
+          ? formatDistanceToNow(new Date(item.file.node.lastUpdated), {
+              locale: {
+                ...locale,
+                formatDistance,
+              },
+              addSuffix: true,
+            })
+          : formatDistanceToNow(new Date(item.file.node.created), {
+              locale: {
+                ...locale,
+                formatDistance,
+              },
+              addSuffix: true,
+            });
+      setRelative(compute());
+      const id = setInterval(() => setRelative(compute()), 60000);
+      return () => clearInterval(id);
+    }, [item, filteredItems.filter]);
 
-      {filteredItems.filter === FilterOptions.RecentlyUpdated
-        ? formatDistanceToNow(new Date(item.file.node.lastUpdated), {
-            locale: {
-              ...locale,
-              formatDistance,
-            },
-            addSuffix: true,
-          })
-        : formatDistanceToNow(new Date(item.file.node.created), {
-            locale: {
-              ...locale,
-              formatDistance,
-            },
-            addSuffix: true,
-          })}
-    </span>
-  );
+    return (
+      <span className="block text-light-grey text-right" suppressHydrationWarning>
+        <FontAwesomeIcon icon={faClock} size="sm" className="mr-1" />
+        {relative}
+      </span>
+    );
+  };
 
   const sanitizeRule = (item) => {
     let rule = sanitizeName(item, true);

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -58,12 +58,13 @@ const Rule = ({ data, location }) => {
                             data.history.nodes[0].lastUpdatedBy
                           )}
                         </strong>{' '}
-                        <span className="opacity-60 pr-1">
-                          {formatDistance(
-                            new Date(data.history.nodes[0].lastUpdated),
-                            new Date()
-                          )}{' '}
-                          ago.
+                        <span className="opacity-60 pr-1" suppressHydrationWarning>
+                          {typeof window === 'undefined'
+                            ? ''
+                            : `${formatDistance(
+                                new Date(data.history.nodes[0].lastUpdated),
+                                new Date()
+                              )} ago.`}
                         </span>
                         <a
                           title={`Created ${format(


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->
We are getting hammered by hydration mismatch browser exceptions - about 2 million in the last 30 days causing spikes in Azure spend. After investigation this is likely due to not setting our dates inside react useEffects.

<img width="1713" height="951" alt="image" src="https://github.com/user-attachments/assets/769e83f5-f64b-4d56-996e-cd9d73e50d0e" />

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
