### PR TITLE
💄 UI - Add more space above the h2

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -812,7 +812,11 @@ blockquote :last-child {
     margin-top: 1rem;
   }
 
-.rule-content h2, .rule-content h3, .rule-content h4, .rule-content h5, .rule-content h6, .rule-content .h1, .rule-content .h2, .rule-content .h3, .rule-content .h4, .rule-content .h5, .rule-content .h6 {
+.rule-content h2 {
+  margin-top: 3rem;
+}
+
+.rule-content h3, .rule-content h4, .rule-content h5, .rule-content h6, .rule-content .h1, .rule-content .h2, .rule-content .h3, .rule-content .h4, .rule-content .h5, .rule-content .h6 {
   margin-top: 2rem;
 }
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to email: Rules - space above heading

Change:
- Added more space above the h2

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->
<img width="2034" height="1525" alt="image" src="https://github.com/user-attachments/assets/11d93a12-bedb-4f39-9462-e0d3e58fc362" />
**Figure: “Ensure others have permissions” have more space above it**


<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
