### PR TITLE
use GATSBY_ prefix for disable env var

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -173,7 +173,7 @@ jobs:
         run: yarn build
         env:
           GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
-          APPLICATIONINSIGHTS_DISABLED: 'true'
+          GATSBY_APPLICATIONINSIGHTS_DISABLED: 'true'
         timeout-minutes: 30
 
       - name: Archive artifacts

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ const axios = require('axios');
 const { getViewDataFromCRM } = require('./src/services/crmApi');
 
 if (
-  process.env.APPLICATIONINSIGHTS_DISABLED !== 'true' &&
+  process.env.GATSBY_APPLICATIONINSIGHTS_DISABLED !== 'true' &&
   process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
 ) {
   // Log build time stats to appInsights

--- a/src/hooks/useAppInsights.js
+++ b/src/hooks/useAppInsights.js
@@ -4,7 +4,7 @@ export default function useAppInsights() {
   const ai =
     typeof window !== 'undefined' &&
     process.env.APPLICATIONINSIGHTS_CONNECTION_STRING &&
-    process.env.APPLICATIONINSIGHTS_DISABLED !== 'true' &&
+    process.env.GATSBY_APPLICATIONINSIGHTS_DISABLED !== 'true' &&
     new ApplicationInsights({
       config: {
         connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,


### PR DESCRIPTION

<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Relates to #2080 

Replace APPLICATIONINSIGHTS_DISABLED with GATSBY_APPLICATIONINSIGHTS_DISABLED  to align with Gatsby's naming conventions.

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
