### PR TITLE
Update Rule History - If file no longer exists then skip file

### DIFF
--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -66,7 +66,7 @@ $historyArray | Foreach-Object {
                     $fullPath = Join-Path $rulesContentFolder $_
                     if (!(Test-Path $fullPath)) {
                         Write-Output "Skipping missing file: $fullPath"
-                        continue
+                        return
                     }
                     $createdRecord = git log --diff-filter=A --reverse --pretty="%ad<LINE>%aN<LINE>%ae<LINE>" --date=iso-strict -- $_
                     $createdDetails = $createdRecord -split "<LINE>"


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

It is possible to rename rule folders. If we rename rule folders then we need to handle delete operations in git in the update-history.ps1 build script. This PR skips over any previously deleted rule folders

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
