### PR TITLE
Update Rule History build script - use continue to keep interating over rules

### DIFF
--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -66,7 +66,7 @@ $historyArray | Foreach-Object {
                     $fullPath = Join-Path $rulesContentFolder $_
                     if (!(Test-Path $fullPath)) {
                         Write-Output "Skipping missing file: $fullPath"
-                        return
+                        continue
                     }
                     $createdRecord = git log --diff-filter=A --reverse --pretty="%ad<LINE>%aN<LINE>%ae<LINE>" --date=iso-strict -- $_
                     $createdDetails = $createdRecord -split "<LINE>"


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

The return statement is causing the script to stop running, we instead want to keep iterating over all rules

<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
