### PR TITLE
Fix rule history sync by correcting content path resolution

### DIFF
--- a/build-scripts/update-rule-history.ps1
+++ b/build-scripts/update-rule-history.ps1
@@ -41,7 +41,7 @@ $historyChangeEntry = $listOfCommits -join "<LINE>"
 $historyArray = $historyChangeEntry -split "<HISTORY_ENTRY>"
 
 $commitSyncHash = "";
-$rulesContentFolder = "./SSW.Rules.Content/"
+$rulesContentFolder = ".
 
 $historyArray | Foreach-Object {
     $historyEntry = $_ -split "<FILES_CHANGED>"


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish as per https://www.ssw.com.au/rules/write-a-good-pull-request/ -->

Fix incorrect path resolution in update-rule-history script that caused rule files to be skipped during history sync.


<!-- Add done video, screenshots as per https://www.ssw.com.au/rules/record-a-quick-and-dirty-done-video/-->

<!-- As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the task - Call someone to review your changes to get them merged ASAP -->
