### PR TITLE
Run CodeAuditor scan daily instead of weekly

### DIFF
--- a/.github/workflows/codeauditor-test.yml
+++ b/.github/workflows/codeauditor-test.yml
@@ -3,7 +3,7 @@ name: Scheduled CodeAuditor test
 # Schedule scan for SSW Rules at 1pm every Friday
 on: 
   schedule:
-  - cron: "0 2 * * 5"
+  - cron: "0 2 * * *"
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Description
✏️ 
Update the GitHub Actions schedule so the CodeAuditor scan runs every day rather than once a week.

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->