### PR TITLE
Changing pagination logic: only 3 options (20, 50 or all) depending o…

### DIFF
--- a/app/[filename]/page.tsx
+++ b/app/[filename]/page.tsx
@@ -234,7 +234,7 @@ export default async function Page({
     const includeArchived = String(sp.archived ?? "") === "true";
     const view = String(sp.view ?? "blurb") as "titleOnly" | "blurb" | "all";
     const page = Math.max(1, parseInt(String(sp.page ?? "1"), 10) || 1);
-    const perPage = Math.max(1, Math.min(50, parseInt(String(sp.perPage ?? "10"), 10) || 10));
+    const perPage = parseInt(String(sp.perPage ?? "20"), 10) || 20;
 
     return (
       <Section>

--- a/app/user/client-page.tsx
+++ b/app/user/client-page.tsx
@@ -28,7 +28,7 @@ export default function UserRulesClientPage({ ruleCount }) {
   const [nextPageCursor, setNextPageCursor] = useState("");
   const [hasNext, setHasNext] = useState(false);
   const [currentPageLastModified, setCurrentPageLastModified] = useState(1);
-  const [itemsPerPageLastModified, setItemsPerPageLastModified] = useState(10);
+  const [itemsPerPageLastModified, setItemsPerPageLastModified] = useState(20);
 
   // Acknowledged
   const [authoredRules, setAuthoredRules] = useState<any[]>([]);
@@ -39,7 +39,7 @@ export default function UserRulesClientPage({ ruleCount }) {
   const [loadingMoreAuthored, setLoadingMoreAuthored] = useState(false);
   const [githubError, setGithubError] = useState<string | null>(null);
   const [currentPageAuthored, setCurrentPageAuthored] = useState(1);
-  const [itemsPerPageAuthored, setItemsPerPageAuthored] = useState(10);
+  const [itemsPerPageAuthored, setItemsPerPageAuthored] = useState(20);
   const FETCH_PAGE_SIZE = 10;
 
   const resolveAuthor = async (): Promise<string> => {

--- a/components/rule-list/rule-list-wrapper.tsx
+++ b/components/rule-list/rule-list-wrapper.tsx
@@ -18,10 +18,10 @@ export interface RuleListWrapperProps {
   initialPerPage?: number;
 }
 
-const RuleListWrapper: React.FC<RuleListWrapperProps> = ({ 
+const RuleListWrapper: React.FC<RuleListWrapperProps> = ({
   initialView = 'blurb',
   initialPage = 1,
-  initialPerPage = 10,
+  initialPerPage = 20,
   ...props 
 }) => {
   const [filter, setFilter] = useState<RuleListFilter>(() => {

--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -38,7 +38,7 @@ const RuleList: React.FC<RuleListProps> = ({
   showFilterControls = true,
   initialFilter = RuleListFilter.Blurb,
   initialPage = 1,
-  initialItemsPerPage = 10,
+  initialItemsPerPage = 20,
   externalCurrentPage,
   externalItemsPerPage,
 }) => {

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -21,13 +21,25 @@ export default function Pagination({ currentPage, totalPages, totalItems, itemsP
   const startItem = isShowingAll ? 1 : (currentPage - 1) * itemsPerPage + 1;
   const endItem = isShowingAll ? totalItems : Math.min(currentPage * itemsPerPage, totalItems);
 
-  const itemsPerPageOptions = [
-    { value: "5", label: "5" },
-    { value: "10", label: "10" },
-    { value: "20", label: "20" },
-    { value: "50", label: "50" },
-    { value: totalItems.toString(), label: "All" },
-  ];
+  const getItemsPerPageOptions = () => {
+    if (totalItems <= 20) {
+      return [];
+    }
+    if (totalItems <= 50) {
+      return [
+        { value: "20", label: "20" },
+        { value: totalItems.toString(), label: "All" },
+      ];
+    }
+    return [
+      { value: "20", label: "20" },
+      { value: "50", label: "50" },
+      { value: totalItems.toString(), label: "All" },
+    ];
+  };
+
+  const itemsPerPageOptions = getItemsPerPageOptions();
+  const showDropdown = totalItems > 20;
 
   const getVisiblePages = () => {
     const pages: (number | string)[] = [];
@@ -112,21 +124,23 @@ export default function Pagination({ currentPage, totalPages, totalItems, itemsP
         )}
 
         {/* Items per page and count */}
-        <div className="flex items-center gap-4 text-sm text-gray-600">
-          <div className="flex items-center gap-2">
-            <Dropdown
-              options={itemsPerPageOptions}
-              value={itemsPerPage.toString()}
-              onChange={(value) => onItemsPerPageChange(parseInt(value))}
-              className="text-sm"
-              showBorder={true}
-            />
-            <span className="mr-8">per page</span>
+        {showDropdown && (
+          <div className="flex items-center gap-4 text-sm text-gray-600">
+            <div className="flex items-center gap-2">
+              <Dropdown
+                options={itemsPerPageOptions}
+                value={itemsPerPage.toString()}
+                onChange={(value) => onItemsPerPageChange(parseInt(value))}
+                className="text-sm"
+                showBorder={true}
+              />
+              <span className="mr-8">per page</span>
+            </div>
+            <span>
+              {startItem} - {endItem} of {totalItems} items
+            </span>
           </div>
-          <span>
-            {startItem} - {endItem} of {totalItems} items
-          </span>
-        </div>
+        )}
       </div>
 
       {/* Mobile layout */}
@@ -173,21 +187,23 @@ export default function Pagination({ currentPage, totalPages, totalItems, itemsP
         )}
 
         {/* Items per page and count - centered on new line */}
-        <div className="flex items-center justify-center gap-4 text-sm text-gray-600">
-          <div className="flex items-center gap-2">
-            <Dropdown
-              options={itemsPerPageOptions}
-              value={itemsPerPage.toString()}
-              onChange={(value) => onItemsPerPageChange(parseInt(value))}
-              className="text-sm"
-              showBorder={true}
-            />
-            <span className="mr-8">per page</span>
+        {showDropdown && (
+          <div className="flex items-center justify-center gap-4 text-sm text-gray-600">
+            <div className="flex items-center gap-2">
+              <Dropdown
+                options={itemsPerPageOptions}
+                value={itemsPerPage.toString()}
+                onChange={(value) => onItemsPerPageChange(parseInt(value))}
+                className="text-sm"
+                showBorder={true}
+              />
+              <span className="mr-8">per page</span>
+            </div>
+            <span>
+              {startItem} - {endItem} of {totalItems} items
+            </span>
           </div>
-          <span>
-            {startItem} - {endItem} of {totalItems} items
-          </span>
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
…n the context.

## Description

I've updated the pagination system depending on the context:
- only 3 options available: 20, 50 or all (rules per page)
- If rules under 20, the dropdown is hidden
- the option are available depending on how many rules there is in total for each category

## Screenshot (optional)
N/A - It's visibly the same as before.

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->