### PR TITLE
Hiding category edit in TinaMode

### DIFF
--- a/app/[filename]/ServerCategoryPage.tsx
+++ b/app/[filename]/ServerCategoryPage.tsx
@@ -1,11 +1,9 @@
 import Link from "next/link";
-import { RiGithubLine, RiPencilLine } from "react-icons/ri";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import { CategoryEdit } from "@/components/CategoryEdit";
 import RuleListWrapper from "@/components/rule-list/rule-list-wrapper";
 import MarkdownComponentMapping from "@/components/tina-markdown/markdown-component-mapping";
-import { IconLink } from "@/components/ui";
-import { ICON_SIZE } from "@/constants";
 
 interface ServerCategoryPageProps {
   category: any;
@@ -34,20 +32,7 @@ export default function ServerCategoryPage({ category, path, includeArchived, vi
         <div className="w-full lg:w-2/3 bg-white pt-4 p-6 border border-[#CCC] rounded shadow-lg">
           <div className="flex justify-between">
             <h1 className="m-0 mb-4 text-ssw-red font-bold">{includeArchived ? `Archived Rules - ${title}` : title}</h1>
-
-            <div className="flex gap-2 justify-center items-start sm:items-center">
-              <IconLink href={`admin/index.html#/collections/edit/category/${path?.slice(0, -4)}`} title="Edit category" tooltipOpaque={true}>
-                <RiPencilLine size={ICON_SIZE} />
-              </IconLink>
-              <IconLink
-                href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/${process.env.NEXT_PUBLIC_TINA_BRANCH}/categories/${path}`}
-                target="_blank"
-                title="View category on GitHub"
-                tooltipOpaque={true}
-              >
-                <RiGithubLine size={ICON_SIZE} className="rule-icon" />
-              </IconLink>
-            </div>
+            <CategoryEdit path={path} />
           </div>
 
           <div className="text-md rule-content">

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -13,7 +13,6 @@ import SearchBar from "@/components/SearchBarWrapper";
 import { Card } from "@/components/ui/card";
 import WhyRulesCard from "@/components/WhyRulesCard";
 import { LatestRule } from "@/models/LatestRule";
-import { Rule } from "@/models/Rule";
 import { QuickLink } from "@/types/quickLink";
 
 export interface HomeClientPageProps {

--- a/components/CategoryEdit.tsx
+++ b/components/CategoryEdit.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { RiGithubLine, RiPencilLine } from "react-icons/ri";
+import { ICON_SIZE } from "@/constants";
+import { useIsAdminPage } from "./hooks/useIsAdminPage";
+import { IconLink } from "./ui";
+
+export const CategoryEdit = ({ path }: { path?: string }) => {
+  const { isAdmin: isAdminPage } = useIsAdminPage();
+  if (!path || isAdminPage) return null;
+
+  return (
+    <div className="flex gap-2 justify-center items-start sm:items-center">
+      <IconLink href={`admin/index.html#/collections/edit/category/${path?.slice(0, -4)}`} title="Edit category" tooltipOpaque={true}>
+        <RiPencilLine size={ICON_SIZE} />
+      </IconLink>
+      <IconLink
+        href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/${process.env.NEXT_PUBLIC_TINA_BRANCH}/categories/${path}`}
+        target="_blank"
+        title="View category on GitHub"
+        tooltipOpaque={true}
+      >
+        <RiGithubLine size={ICON_SIZE} className="rule-icon" />
+      </IconLink>
+    </div>
+  );
+};


### PR DESCRIPTION
Fixed: #2246 

## Screenshot (optional)
✏️ 

<img width="2531" height="1110" alt="image" src="https://github.com/user-attachments/assets/06b0d356-5095-43d5-bc4c-5fcf8b3dfbda" />

**Figure: Category page without editable icons in tina mode** 