### PR TITLE
Change CodeAuditor schedule to weekly

### DIFF
--- a/.github/workflows/codeauditor-test.yml
+++ b/.github/workflows/codeauditor-test.yml
@@ -1,9 +1,9 @@
 name: Scheduled CodeAuditor test
 
-# Schedule scan for SSW Rules at 1pm every Friday
+# Weekly scan at 1:00 AM US Eastern Time
 on: 
   schedule:
-  - cron: "0 2 * * *"
+  - cron: "0 6 * * 5"
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Description
✏️ 
Relates to #2270 

Update CodeAuditor workflow schedule to weekly 1:00 AM

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->