### PR TITLE
Adjust margin styles for headings in styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -219,11 +219,15 @@
   h4,
   h5,
   h6 {
-    @apply mt-2 mb-4 text-gray-900 leading-[1.2] font-semibold;
+    @apply mt-4 mb-4 text-gray-900 leading-[1.2] font-semibold;
   }
 
   h2 {
-    @apply mt-12 text-3xl;
+    text-3xl;
+  }
+
+  h2:not(:first-child), h3:not(:first-child) {
+    @apply mt-8;
   }
 
   h3 {


### PR DESCRIPTION
Made H2 only have margin top if NOT the first-child, which will prevent the odd space on top of email templates

fixes https://github.com/SSWConsulting/SSW.Rules/issues/2268

cc @micsblank @Aibono1225 @designbyalex 