### PR TITLE
BoxEmbed - Add code block overflow handling

### DIFF
--- a/components/embeds/boxEmbed.tsx
+++ b/components/embeds/boxEmbed.tsx
@@ -2,14 +2,14 @@ import { CodeXml, Info, TriangleAlert } from "lucide-react";
 import React from "react";
 import ReactCountryFlag from "react-country-flag";
 import { FaLightbulb } from "react-icons/fa6";
-import { withBasePath } from "@/lib/withBasePath";
 import { Template } from "tinacms";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import { withBasePath } from "@/lib/withBasePath";
 import { toolbarFields } from "@/tina/collection/shared/toolbarFields";
 import MarkdownComponentMapping from "../tina-markdown/markdown-component-mapping";
 import { Figure, inlineFigureDefaultItem, inlineFigureFields } from "./figure";
-import { youtubeEmbedTemplate } from "./youtubeEmbed";
 import { imageEmbedTemplate } from "./imageEmbed";
+import { youtubeEmbedTemplate } from "./youtubeEmbed";
 
 function YakShaveIcon() {
   return (
@@ -104,10 +104,16 @@ export function BoxEmbed(props: any) {
       <div className={`p-4 rounded-sm my-4 ${config.containerClass}`}>
         <div className="flex items-start">
           {config.icon}
-          <div className={`[&_p:last-child]:mb-0 ${config.textClass ?? ""}`}>
-            <div>
-              <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />
-            </div>
+          <div
+            className="
+              min-w-0 w-0 flex-1 break-words whitespace-normal
+              [&_pre]:max-w-full
+              [&_pre]:overflow-x-auto
+              [&_pre]:whitespace-pre
+              [&_img]:max-w-full [&_img]:h-auto
+              [&_p:last-child]:mb-0"
+          >
+            <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2333

Fixed the broken UI caused by the code block overflow



## Screenshot (optional)
✏️ 

**Before:**
<img width="2509" height="1325" alt="image" src="https://github.com/user-attachments/assets/863599ab-63e7-4c7d-9d4e-45bd804d8210" />


**After:**
<img width="2371" height="1287" alt="image" src="https://github.com/user-attachments/assets/62eb3b77-f658-412b-831c-532c053647e0" />



<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->