### PR TITLE
Fix heading anchors being overridden in markdown component mapping

### DIFF
--- a/components/tina-markdown/markdown-component-mapping.tsx
+++ b/components/tina-markdown/markdown-component-mapping.tsx
@@ -67,8 +67,8 @@ export const getMarkdownComponentMapping = (enableAnchors = false): Components<a
     ...embedComponents,
     ...typography,
 
-    p: withHighlightProcessing(typography.p ?? "p"),
-    li: withHighlightProcessing(typography.li ?? "li"),
+    p: withHighlightProcessing("p"),
+    li: withHighlightProcessing("li"),
 
     h1: withHighlightProcessing("h1"),
     h2: withHighlightProcessing(typography.h2),


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1942

Updated the TinaMarkdown component mapping so highlight processing wraps the existing typography components instead of overriding them.


## Screenshot (optional)
✏️ 
<img width="1466" height="818" alt="image" src="https://github.com/user-attachments/assets/34a5e9ae-42bb-404d-8800-ddd2db33d83b" />

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->