### PR TITLE
Fix China icon size

### DIFF
--- a/components/embeds/boxEmbed.tsx
+++ b/components/embeds/boxEmbed.tsx
@@ -47,7 +47,7 @@ const variantConfig: Record<BoxVariant, VariantConfig> = {
     containerClass: "bg-white border",
     icon: (
       <div className="w-8 h-8 mr-4 flex items-start justify-center">
-        <ReactCountryFlag countryCode="CN" svg style={{ width: "1.5em", height: "1.5em" }} />
+        <ReactCountryFlag countryCode="CN" svg className="w-8! h-8!" />
       </div>
     ),
   },


### PR DESCRIPTION
## Description
✏️ 
Relates to #2323 

fix the China box icon, which is in a different size

## Screenshot (optional)
✏️ 
<img width="1939" height="1008" alt="image" src="https://github.com/user-attachments/assets/4c6f2e96-b5f4-4ef1-8dcb-b8276f24d222" />

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->