### PR TITLE
Dropdown page is not removed while scrolling in mobile view

### DIFF
--- a/components/ui/dropdown.tsx
+++ b/components/ui/dropdown.tsx
@@ -32,6 +32,14 @@ export default function Dropdown({ options, value, onChange, className = '', sho
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleScroll = () => setIsOpen(false);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [isOpen]);
+
   const selectedOption = options.find(option => option.value === value);
 
   const handleSelect = (optionValue: string) => {


### PR DESCRIPTION
## Description

PBI - https://github.com/SSWConsulting/SSW.Rules/issues/2090
Now the dropdown is removed while we start to scroll.

## Screenshot (optional)

https://github.com/user-attachments/assets/251a3a92-b886-47ab-aae3-ce2a958f2f96

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->