### PR TITLE
Prevent "Unknown" author names from being hyperlinked

### DIFF
--- a/components/RuleCard.tsx
+++ b/components/RuleCard.tsx
@@ -12,30 +12,18 @@ interface RuleCardProps {
   authorUrl?: string | null;
 }
 
-export default function RuleCard({
-  title,
-  slug,
-  lastUpdatedBy,
-  lastUpdated,
-  index,
-  authorUrl
-}: RuleCardProps) {
+export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl }: RuleCardProps) {
   return (
     <Card className="mb-4">
       <div className="flex">
-        {index !== undefined && (
-          <span className="text-gray-500 mr-2">#{index + 1}</span>
-        )}
+        {index !== undefined && <span className="text-gray-500 mr-2">#{index + 1}</span>}
         <div className="flex flex-col">
           <Link href={`/${slug}`} className="no-underline">
-            <h2 className="m-0 mb-2 text-2xl max-sm:text-lg hover:text-ssw-red">
-              {title}
-            </h2>
+            <h2 className="m-0 mb-2 text-2xl max-sm:text-lg hover:text-ssw-red">{title}</h2>
           </Link>
           <h4 className="flex m-0 content-center text-lg text-gray-400">
             <span className="font-medium">
-              {authorUrl ? (
-                // Always treat authorUrl as external
+              {authorUrl && (lastUpdatedBy || "Unknown") !== "Unknown" ? (
                 <a href={authorUrl} target="_blank" rel="noopener noreferrer" className="underline">
                   {lastUpdatedBy || "Unknown"}
                 </a>


### PR DESCRIPTION
## Description
✏️ 

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2324
Update the author link condition to only render `<a>` when the displayed author name is not "Unknown"

## Screenshot (optional)
✏️ 
<img width="2323" height="1453" alt="image" src="https://github.com/user-attachments/assets/0503f382-cb4c-4005-b1b3-8dda37a63d1b" />



<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->