### PR TITLE
Adding number rules count in the Category title

### DIFF
--- a/app/[filename]/ServerCategoryPage.tsx
+++ b/app/[filename]/ServerCategoryPage.tsx
@@ -31,7 +31,10 @@ export default function ServerCategoryPage({ category, path, includeArchived, vi
       <div className="relative">
         <div className="w-full lg:w-2/3 bg-white pt-4 p-6 border border-[#CCC] rounded shadow-lg">
           <div className="flex justify-between">
-            <h1 className="m-0 mb-4 text-ssw-red font-bold">{includeArchived ? `Archived Rules - ${title}` : title}</h1>
+            <h1 className="m-0 mb-4 text-3xl text-ssw-red font-bold">
+              {includeArchived ? `Archived Rules - ${title}` : title}
+              <span className="text-2xl text-gray-400 font-normal"> - {finalRules.length} Rules</span>
+            </h1>
             <CategoryEdit path={path} />
           </div>
 


### PR DESCRIPTION
## Description

PBI - https://github.com/SSWConsulting/SSW.Rules/issues/2252
- Adding the rules count number to the category title
- Changing the overall size of this header

## Screenshot (optional)

<img width="1119" height="589" alt="image" src="https://github.com/user-attachments/assets/21f53d68-c05e-4bee-8955-7c308b38049b" />

**Figure: new category title layout**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->