### PR TITLE
Tooltip implementation for the last updated date on rule page

### DIFF
--- a/components/last-updated-by/index.tsx
+++ b/components/last-updated-by/index.tsx
@@ -90,7 +90,7 @@ export default function GitHubMetadata({ owner = "tinacms", repo = "tina.io", pa
                   displayAuthorName
                 )}
               </span>
-              <Tooltip text={lastUpdateInAbsoluteTime} showDelay={0} hideDelay={0} opaque={true}>
+              {" "}<Tooltip text={lastUpdateInAbsoluteTime} showDelay={0} hideDelay={0} opaque={true}>
                 <span>{` ${lastUpdateInRelativeTime}.`}</span>
               </Tooltip>
             </span>


### PR DESCRIPTION
## Description

- PBI - https://github.com/SSWConsulting/SSW.Rules/issues/2204
- Adding tool tip to the last updated date on rule page

## Screenshot (optional)

<img width="1135" height="596" alt="image" src="https://github.com/user-attachments/assets/214f1374-e0ca-4b1f-8282-b53e1f2190f8" />

**Figure: tooltip with the date**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->