### PR TITLE
UI - updating box border width to match Figma specs

### DIFF
--- a/components/CategoriesCard.tsx
+++ b/components/CategoriesCard.tsx
@@ -30,7 +30,7 @@ export default function CategoriesCard({ categories }: CategoriesCardProps) {
           <Link
             key={c.uri}
             href={`/${c.uri}`}
-            className="border-2 no-underline border-ssw-red text-ssw-red py-1 px-2 rounded-xs font-semibold hover:text-white hover:bg-ssw-red transition-colors duration-200"
+            className="border no-underline border-ssw-red text-ssw-red py-1 px-2 rounded-xs font-semibold hover:text-white hover:bg-ssw-red transition-colors duration-200"
             // @ts-expect-error tinacms types are wrong
             data-tina-field={tinaField(categories?.[index], "category")}
           >

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ type CardProps = {
 
 export function Card({ children,title,dropShadow, className = "" }: CardProps) {
   return (
-    <div className={`border-2 border-border rounded-sm p-4 bg-card ${dropShadow?'drop-shadow-lg':''} ${className}`}>
+    <div className={`border border-border rounded-sm p-4 bg-card ${dropShadow?'drop-shadow-lg':''} ${className}`}>
       {title && <h3 className="mt-0 text-lg">{title}</h3>}
       {children}
     </div>


### PR DESCRIPTION
## Description

Related PBI: https://github.com/SSWConsulting/SSW.Rules/issues/2005

Updated border width in Card components to match Figma specs (1px)

## Screenshot (optional)

<img width="1720" height="1380" alt="Image" src="https://github.com/user-attachments/assets/3bcdd9db-c417-4552-9753-b83fae4d7b51" />

**Figure: Rule page**

<img width="1720" height="1380" alt="Image" src="https://github.com/user-attachments/assets/d17fbb24-edb4-4915-9330-96f6d97402f9" />

**Figure: Home Page**