### PR TITLE
Fix case sensitivity in 'OK' example message

### DIFF
--- a/components/embeds/figure.tsx
+++ b/components/embeds/figure.tsx
@@ -7,7 +7,7 @@ export function getPrefix(prefix?: FigurePrefix): string {
     case "bad":
       return "❌ Figure: Bad example - ";
     case "ok":
-      return "🙂 Figure: Ok example - ";
+      return "🙂 Figure: OK example - ";
     case "good":
       return "✅ Figure: Good example - ";
     case "none":


### PR DESCRIPTION
as per https://www.ssw.com.au/rules/do-you-use-ok-instead-of-ok

