### PR TITLE
🗒️README - updated f5 instructions to mention running content preparation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ The site pulls data from [SSW Rules Content Repo 📜](https://github.com/SSWCon
 
 5. Run `pnpm install` to install packages
 
-6. Run `pnpm dev` to start the development server
+5. Install the following python package with pip (or `pip3`) `pip install pyyaml`
+
+6. Run `pnpm prepare:content` to prepare the content for local development
+
+7. Run `pnpm dev` to start the development server
 
 
 ### Syncing and Updating Content


### PR DESCRIPTION
## Description

I wasn't able to run the project locally because `rule-to-categories.json` needs to be in the project's local directory. This PR updates the description to mention running the `prepare:content` script which is used to generate the missing file. I also mentioned the need to install `pyyaml` as this is required by the script and is not a standard python library.

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->