### PR TITLE
Trim `uri` field value before submission

### DIFF
--- a/tina/collection/shared/historyFields.ts
+++ b/tina/collection/shared/historyFields.ts
@@ -70,6 +70,10 @@ export const historyFields: TinaField[] = [
 ];
 
 export const historyBeforeSubmit = async ({ form, cms, values }: { form: Form; cms: TinaCMS; values: Record<string, any> }) => {
+  if (typeof values.uri === "string") {
+    values = { ...values, uri: values.uri.trim() };
+  }
+
   let userEmail: string | undefined;
   let userName: string | undefined;
 


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2385

Ensures that the `uri` field value is trimmed of any leading or trailing whitespace before submission. This prevents issues caused by unintended spaces in the `uri` and improves data consistency.

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->