### PR TITLE
Fix deployment settings wipe deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,17 +48,14 @@ jobs:
             AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             AZURE_SERVICE_PRINCIPAL_OBJECT_ID: ${{ secrets.AZURE_SERVICE_PRINCIPAL_OBJECT_ID }}
             AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-            AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+            AUTH0_CLIENT_ID: ${{ vars.AUTH0_CLIENT_ID }}
             AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
             AUTH0_SECRET: ${{ secrets.AUTH0_SECRET }}
             GH_APP_ID: ${{ vars.GH_APP_ID }}
             GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
             GITHUB_APP_INSTALLATION_ID: ${{ secrets.GITHUB_APP_INSTALLATION_ID }}
             CRM_APP_SECRET: ${{ secrets.CRM_APP_SECRET }}
-            CRM_CLIENT_ID: ${{ secrets.CRM_CLIENT_ID }}
-            CRM_TENANT: ${{ secrets.CRM_TENANT }}
-            TINA_TOKEN: ${{ secrets.TINA_TOKEN }}
-            ALGOLIA_APP_ID: ${{ secrets.NEXT_PUBLIC_ALGOLIA_APP_ID }}
+            TINA_WEBHOOK_SECRET: ${{ secrets.TINA_WEBHOOK_SECRET }}
 
     # ============================================================================
     # BUILD AND PUSH CONTAINER
@@ -152,55 +149,32 @@ jobs:
                       echo "Deploying without slot (staging environment)"
                   fi
 
-            - name: Configure Auth0 and Build Info app settings
+            - name: Configure deployment metadata
               run: |
                   SLOT_NAME="${{ steps.slot.outputs.slot_name }}"
 
-                  # Build command as array for safe execution
                   CMD=(
                     az webapp config appsettings set
                     --name "${{ needs.infrastructure.outputs.appServiceName }}"
                     --resource-group "${{ needs.infrastructure.outputs.resourceGroup }}"
                   )
 
-                  # Add slot parameter only if slot name is provided
                   if [ -n "$SLOT_NAME" ]; then
                     CMD+=(--slot "$SLOT_NAME")
                   fi
 
-                  # Add settings and output flag
                   CMD+=(
                     --settings
-                    "TINA_WEBHOOK_SECRET=${{ secrets.TINA_WEBHOOK_SECRET }}"
-                    "AUTH0_DOMAIN=${{ vars.AUTH0_DOMAIN }}"
-                    "AUTH0_CLIENT_ID=${{ vars.AUTH0_CLIENT_ID }}"
-                    "AUTH0_CLIENT_SECRET=${{ secrets.AUTH0_CLIENT_SECRET }}"
-                    "AUTH0_SECRET=${{ secrets.AUTH0_SECRET }}"
-                    "AUTH0_REDIRECT_URI=${{ vars.AUTH0_REDIRECT_URI }}"
-                    "AUTH0_AUDIENCE=${{ vars.AUTH0_AUDIENCE }}"
-                    "GH_APP_ID=${{ vars.GH_APP_ID }}"
-                    "GH_APP_PRIVATE_KEY=${{ secrets.GH_APP_PRIVATE_KEY }}"
-                    "GITHUB_APP_INSTALLATION_ID=${{ secrets.GITHUB_APP_INSTALLATION_ID }}"
-                    "CRM_TENANT=${{ vars.CRM_TENANT }}"
-                    "CRM_TENANT_ID=${{ vars.CRM_TENANT_ID }}"
-                    "CRM_APP_ID=${{ vars.CRM_APP_ID }}"
-                    "CRM_SCOPE=${{ vars.CRM_SCOPE }}"
-                    "CRM_VIEW_CURRENT=${{ vars.CRM_VIEW_CURRENT }}"
-                    "CRM_VIEW_PAST=${{ vars.CRM_VIEW_PAST }}"
-                    "CRM_APP_SECRET=${{ secrets.CRM_APP_SECRET }}"
-                    "NEXT_PUBLIC_API_BASE_URL=${{ vars.NEXT_PUBLIC_API_BASE_URL }}"
-                    "NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING=${{ secrets.NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING }}"
                     "BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}"
                     "VERSION_DEPLOYED=${{ env.VERSION_DEPLOYED }}"
                     "DEPLOYMENT_URL=${{ env.DEPLOYMENT_URL }}"
                     "BUILD_DATE=${{ env.BUILD_DATE }}"
-                    "NEXT_PUBLIC_TINA_BRANCH=${{ vars.NEXT_PUBLIC_TINA_BRANCH }}"
                     "COMMIT_HASH=${{ env.COMMIT_HASH }}"
                     --output none
                   )
 
-                  # Execute the command
                   "${CMD[@]}"
+                  echo "✅ Deployment metadata configured"
 
             - name: Deploy to Azure Web App (Production with slot)
               if: github.event.inputs.environment == 'production'

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -112,19 +112,6 @@ jobs:
           $params['Environment'] = "${{ inputs.environment }}"
           $params['ResourceGroup'] = "${{ vars.AZURE_RESOURCE_GROUP }}"
           $params['ServicePrincipalObjectId'] = "${{ secrets.AZURE_SERVICE_PRINCIPAL_OBJECT_ID }}"
-          
-          # Runtime environment variables
-          $params['Auth0Domain'] = "${{ secrets.AUTH0_DOMAIN }}"
-          $params['Auth0ClientId'] = "${{ secrets.AUTH0_CLIENT_ID }}"
-          $params['Auth0ClientSecret'] = "${{ secrets.AUTH0_CLIENT_SECRET }}"
-          $params['Auth0Secret'] = "${{ secrets.AUTH0_SECRET }}"
-          $params['GhAppId'] = "${{ secrets.GH_APP_ID }}"
-          $params['GhAppPrivateKey'] = "${{ secrets.GH_APP_PRIVATE_KEY }}"
-          $params['GithubAppInstallationId'] = "${{ secrets.GITHUB_APP_INSTALLATION_ID }}"
-          $params['CrmAppSecret'] = "${{ secrets.CRM_APP_SECRET }}"
-          $params['CrmClientId'] = "${{ secrets.CRM_CLIENT_ID }}"
-          $params['TinaToken'] = "${{ secrets.TINA_TOKEN }}"
-          $params['AlgoliaAppId'] = "${{ secrets.ALGOLIA_APP_ID }}"
 
           $slotName = "${{ inputs.slot_name }}"
           if ($slotName) {
@@ -132,6 +119,48 @@ jobs:
           }
 
           ./infra/deploy.ps1 @params
+
+      - name: Configure all app settings
+        run: |
+          SLOT_NAME="${{ inputs.slot_name }}"
+          
+          CMD=(
+            az webapp config appsettings set
+            --name "${{ steps.deploy.outputs.appServiceName }}"
+            --resource-group "${{ steps.deploy.outputs.resourceGroup }}"
+          )
+          
+          if [ -n "$SLOT_NAME" ]; then
+            CMD+=(--slot "$SLOT_NAME")
+          fi
+          
+          CMD+=(
+            --settings
+            "AUTH0_DOMAIN=${{ secrets.AUTH0_DOMAIN }}"
+            "AUTH0_CLIENT_ID=${{ secrets.AUTH0_CLIENT_ID }}"
+            "AUTH0_CLIENT_SECRET=${{ secrets.AUTH0_CLIENT_SECRET }}"
+            "AUTH0_SECRET=${{ secrets.AUTH0_SECRET }}"
+            "AUTH0_REDIRECT_URI=${{ vars.AUTH0_REDIRECT_URI }}"
+            "AUTH0_AUDIENCE=${{ vars.AUTH0_AUDIENCE }}"
+            "GH_APP_ID=${{ vars.GH_APP_ID }}"
+            "GH_APP_PRIVATE_KEY=${{ secrets.GH_APP_PRIVATE_KEY }}"
+            "GITHUB_APP_INSTALLATION_ID=${{ secrets.GITHUB_APP_INSTALLATION_ID }}"
+            "CRM_TENANT=${{ vars.CRM_TENANT }}"
+            "CRM_TENANT_ID=${{ vars.CRM_TENANT_ID }}"
+            "CRM_APP_ID=${{ vars.CRM_APP_ID }}"
+            "CRM_SCOPE=${{ vars.CRM_SCOPE }}"
+            "CRM_VIEW_CURRENT=${{ vars.CRM_VIEW_CURRENT }}"
+            "CRM_VIEW_PAST=${{ vars.CRM_VIEW_PAST }}"
+            "CRM_APP_SECRET=${{ secrets.CRM_APP_SECRET }}"
+            "TINA_WEBHOOK_SECRET=${{ secrets.TINA_WEBHOOK_SECRET }}"
+            "NEXT_PUBLIC_API_BASE_URL=${{ vars.NEXT_PUBLIC_API_BASE_URL }}"
+            "NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING=${{ steps.deploy.outputs.appInsightsConnectionString }}"
+            "NEXT_PUBLIC_TINA_BRANCH=${{ vars.NEXT_PUBLIC_TINA_BRANCH }}"
+            --output none
+          )
+          
+          "${CMD[@]}"
+          echo "✅ App settings configured successfully"
 
       - name: Log infrastructure outputs
         run: |

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -61,43 +61,6 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$SlotName = '',
 
-    # Runtime environment variables (secrets)
-    [Parameter(Mandatory = $true)]
-    [string]$Auth0Domain,
-
-    [Parameter(Mandatory = $true)]
-    [string]$Auth0ClientId,
-
-    [Parameter(Mandatory = $true)]
-    [string]$Auth0ClientSecret,
-
-    [Parameter(Mandatory = $true)]
-    [string]$Auth0Secret,
-
-    [Parameter(Mandatory = $true)]
-    [string]$GhAppId,
-
-    [Parameter(Mandatory = $true)]
-    [string]$GhAppPrivateKey,
-
-    [Parameter(Mandatory = $true)]
-    [string]$GithubAppInstallationId,
-
-    [Parameter(Mandatory = $true)]
-    [string]$CrmAppSecret,
-
-    [Parameter(Mandatory = $true)]
-    [string]$CrmClientId,
-
-    [Parameter(Mandatory = $true)]
-    [string]$TinaToken,
-
-    [Parameter(Mandatory = $true)]
-    [string]$AlgoliaSearchKey,
-
-    [Parameter(Mandatory = $true)]
-    [string]$AlgoliaAppId,
-
     [Parameter(Mandatory = $false)]
     [switch]$WhatIf
 )
@@ -438,18 +401,6 @@ $azArgs = @(
     '--parameters', "appServicePlanName=$AppServicePlanName"
     '--parameters', "appServicePlanResourceGroup=$AppServicePlanResourceGroup"
     '--parameters', "appServicePlanSku=$AppServicePlanSku"
-    '--parameters', "auth0Domain=$Auth0Domain"
-    '--parameters', "auth0ClientId=$Auth0ClientId"
-    '--parameters', "auth0ClientSecret=$Auth0ClientSecret"
-    '--parameters', "auth0Secret=$Auth0Secret"
-    '--parameters', "ghAppId=$GhAppId"
-    '--parameters', "ghAppPrivateKey=$GhAppPrivateKey"
-    '--parameters', "githubAppInstallationId=$GithubAppInstallationId"
-    '--parameters', "crmAppSecret=$CrmAppSecret"
-    '--parameters', "crmClientId=$CrmClientId"
-    '--parameters', "tinaToken=$TinaToken"
-    '--parameters', "algoliaSearchKey=$AlgoliaSearchKey"
-    '--parameters', "algoliaAppId=$AlgoliaAppId"
 )
 
 if ($ServicePrincipalObjectId) {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -68,55 +68,6 @@ param tags object = {
 @description('Optional: Name of the deployment slot (e.g., pr-123). If empty, no slot is created.')
 param slotName string = ''
 
-// Runtime environment variables (secrets and configuration)
-@secure()
-@description('Auth0 Domain')
-param auth0Domain string
-
-@secure()
-@description('Auth0 Client ID')
-param auth0ClientId string
-
-@secure()
-@description('Auth0 Client Secret')
-param auth0ClientSecret string
-
-@secure()
-@description('Auth0 Secret')
-param auth0Secret string
-
-@secure()
-@description('GitHub App ID')
-param ghAppId string
-
-@secure()
-@description('GitHub App Private Key')
-param ghAppPrivateKey string
-
-@secure()
-@description('GitHub App Installation ID')
-param githubAppInstallationId string
-
-@secure()
-@description('CRM App Secret')
-param crmAppSecret string
-
-@secure()
-@description('CRM Client ID')
-param crmClientId string
-
-@secure()
-@description('Tina Token')
-param tinaToken string
-
-@secure()
-@description('Algolia Search Key')
-param algoliaSearchKey string
-
-@secure()
-@description('Algolia App ID')
-param algoliaAppId string
-
 // ============================================================================
 // VARIABLES - Well-known Azure Role Definition IDs
 // ============================================================================
@@ -201,19 +152,6 @@ module appServiceModule 'modules/appService.bicep' = {
     imageTag: imageTag
     tags: tags
     slotName: slotName
-    // Runtime environment variables
-    auth0Domain: auth0Domain
-    auth0ClientId: auth0ClientId
-    auth0ClientSecret: auth0ClientSecret
-    auth0Secret: auth0Secret
-    ghAppId: ghAppId
-    ghAppPrivateKey: ghAppPrivateKey
-    githubAppInstallationId: githubAppInstallationId
-    crmAppSecret: crmAppSecret
-    crmClientId: crmClientId
-    tinaToken: tinaToken
-    algoliaSearchKey: algoliaSearchKey
-    algoliaAppId: algoliaAppId
   }
   dependsOn: [
     containerRegistryModule

--- a/infra/modules/appService.bicep
+++ b/infra/modules/appService.bicep
@@ -28,56 +28,6 @@ param tags object = {}
 @description('Optional: Name of the deployment slot (e.g., pr-123). If empty, no slot is created.')
 param slotName string = ''
 
-// Runtime environment variables (secrets and configuration)
-@secure()
-@description('Auth0 Domain')
-param auth0Domain string
-
-@secure()
-@description('Auth0 Client ID')
-param auth0ClientId string
-
-@secure()
-@description('Auth0 Client Secret')
-param auth0ClientSecret string
-
-@secure()
-@description('Auth0 Secret')
-param auth0Secret string
-
-@secure()
-@description('GitHub App ID')
-param ghAppId string
-
-@secure()
-@description('GitHub App Private Key')
-param ghAppPrivateKey string
-
-@secure()
-@description('GitHub App Installation ID')
-param githubAppInstallationId string
-
-
-@secure()
-@description('CRM App Secret')
-param crmAppSecret string
-
-@secure()
-@description('CRM Client ID')
-param crmClientId string
-
-@secure()
-@description('Tina Token')
-param tinaToken string
-
-@secure()
-@description('Algolia Search Key')
-param algoliaSearchKey string
-
-@secure()
-@description('Algolia App ID')
-param algoliaAppId string
-
 // ============================================================================
 // VARIABLES
 // ============================================================================
@@ -109,51 +59,6 @@ var baseAppSettings = [
   {
     name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
     value: appInsightsConnectionString
-  }
-  // Runtime environment variables
-  {
-    name: 'AUTH0_DOMAIN'
-    value: auth0Domain
-  }
-  {
-    name: 'AUTH0_CLIENT_ID'
-    value: auth0ClientId
-  }
-  {
-    name: 'AUTH0_CLIENT_SECRET'
-    value: auth0ClientSecret
-  }
-  {
-    name: 'AUTH0_SECRET'
-    value: auth0Secret
-  }
-  {
-    name: 'GH_APP_ID'
-    value: ghAppId
-  }
-  {
-    name: 'GH_APP_PRIVATE_KEY'
-    value: ghAppPrivateKey
-  }
-  {
-    name: 'GITHUB_APP_INSTALLATION_ID'
-    value: githubAppInstallationId
-  }
-  {
-    name: 'CRM_APP_SECRET'
-    value: crmAppSecret
-  }
-  {
-    name: 'CRM_CLIENT_ID'
-    value: crmClientId
-  }
-  {
-    name: 'TINA_TOKEN'
-    value: tinaToken
-  }
-  {
-    name: 'ALGOLIA_APP_ID'
-    value: algoliaAppId
   }
 ]
 


### PR DESCRIPTION
## Description
Based on my investigation the environment variables for the app service are getting removed at the start of a deployment, causing the GitHub metadata fetch to fail because the private key is removed. This PR adds the environment settings to the app service at the beginning of the flow so that they will still be accessible for the running service.

## Screenshot (optional)
<img width="1280" height="816" alt="CleanShot 2026-02-13 at 16 42 23" src="https://github.com/user-attachments/assets/d5f983c1-ceec-49b7-8d42-89cd7fea625f" />
**Figure: Fixes this**