### PR TITLE
Adjusts font size for rule count in header

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -36,7 +36,7 @@ export default function HomeClientPage(props: HomeClientPageProps) {
       <SearchBar />
       <div className="max-sm:h-auto m-4">
         <h1 className="m-0 mb-4 flex items-end max-sm:flex-col max-sm:items-start">
-          <span className="text-ssw-red font-bold">{ruleCount.toLocaleString("en-US")}&nbsp;</span>
+          <span className="text-ssw-red font-bold text-[2rem]">{ruleCount.toLocaleString("en-US")}&nbsp;</span>
           <span className="text-gray-600 text-lg font-normal">Best Practices for Better Software & Better Teams</span>
         </h1>
       </div>


### PR DESCRIPTION
## Description
✏️ 
Adjust the font size of the rule number so it matches the one on the rule-legacy website.

## Screenshot (optional)
✏️ 
Before:
<img width="2280" height="1402" alt="image" src="https://github.com/user-attachments/assets/8b3f41c4-350a-49e1-9782-18c997c3e809" />


After:
<img width="2246" height="1330" alt="image" src="https://github.com/user-attachments/assets/bfcd3fcf-aeb4-43c5-8d43-73dd10780390" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->