### PR TITLE
Add thumbnail field to GraphQL queries for display

### DIFF
--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -267,6 +267,7 @@ query ruleData($relativePath: String!) {
       title
       uri
       body
+      thumbnail
       authors {
         title
         url
@@ -323,6 +324,7 @@ query ruleDataBasic($relativePath: String!) {
       title
       uri
       body
+      thumbnail
       authors {
         title
         url


### PR DESCRIPTION
## Description
✏️ 
Relates to #2469 

Add thumbnail field to GraphQL queries for display.

## Screenshot (optional)
✏️ 

<img width="2488" height="1200" alt="image" src="https://github.com/user-attachments/assets/9b145963-4dc6-4103-95d9-61272d490652" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->