### PR TITLE
Add www to SSW People link

### DIFF
--- a/tina/collection/rule.tsx
+++ b/tina/collection/rule.tsx
@@ -116,7 +116,7 @@ const Rule: Collection = {
         itemProps: (item) => ({ label: "👤 " + (item?.title ?? "Author") }),
         defaultItem: {
           title: "Bob Northwind",
-          url: "https://ssw.com.au/people/bob-northwind",
+          url: "https://www.ssw.com.au/people/bob-northwind",
         },
         component: ConditionalHiddenField,
       },
@@ -132,7 +132,7 @@ const Rule: Collection = {
         },
         {
           type: "string",
-          description: "The SSW People link for the contributor. E.g. \"https://ssw.com.au/people/bob-northwind\"",
+          description: "The SSW People link for the contributor. E.g. \"https://www.ssw.com.au/people/bob-northwind\"",
           name: "url",
           label: "Url",
         },


### PR DESCRIPTION
## Description

Changes the default SSW People link from `https://ssw.com.au/people/bob-northwind` to `https://www.ssw.com.au/people/bob-northwind`.

Should stop URL Linter Warnings for new rules like https://github.com/SSWConsulting/SSW.Rules.Content/pull/12132#issuecomment-3995516841

<img width="808" height="380" alt="github com_SSWConsulting_SSW Rules Content_pull_12132" src="https://github.com/user-attachments/assets/1974cd54-c07b-4aaf-b7bd-8edd4bedd0a4" />

**Figure - Example of a URL Linter Warning**