### PR TITLE
Adding Mermaid branding and style configuration.

### DIFF
--- a/components/mermaid/mermaid-theme.ts
+++ b/components/mermaid/mermaid-theme.ts
@@ -1,14 +1,13 @@
 import type { MermaidConfig } from "mermaid";
-import { colors } from "@/site-config";
 
-// SSW brand colors — sourced from the project's single color palette (site-config.ts)
-const SSW_RED = colors.sswRed;
-const SSW_RED_LIGHT = colors.sswLightRed;
-const SSW_RED_TINT = colors.sswRedTint;
-const SSW_GRAY = colors.sswGray;
-const SSW_BLACK = colors.sswBlack;
-const SSW_LIGHT_BG = colors.sswLightBg;
-const WHITE = colors.white;
+// SSW brand colors — keep these in sync with the @theme block in styles.css
+const SSW_RED = "#cc4141";
+const SSW_RED_LIGHT = "#d26e6e";
+const SSW_RED_TINT = "#fdecea"; // very light red for shape fills
+const SSW_GRAY = "#797979";
+const SSW_BLACK = "#333333";
+const SSW_LIGHT_BG = "#f6f8fa";
+const WHITE = "#ffffff";
 
 export const sswMermaidConfig: MermaidConfig = {
   startOnLoad: false,

--- a/site-config.ts
+++ b/site-config.ts
@@ -14,17 +14,6 @@ export const siteUrl = `https://www.ssw.com.au/rules`;
 export const siteUrlRelative = `/`;
 export const themeColor = `#cc4141`;
 export const backgroundColor = `#fff`;
-
-// SSW brand color palette — single source of truth for TypeScript consumers
-export const colors = {
-  sswRed: "#cc4141",
-  sswLightRed: "#d26e6e",
-  sswRedTint: "#fdecea", // very light red, used for shape fills
-  sswGray: "#797979",
-  sswBlack: "#333333",
-  sswLightBg: "#f6f8fa", // matches --color-table-odd
-  white: "#ffffff",
-} as const;
 export const pathPrefix = `/rules`;
 export const social = {
   twitter: `SSW_TV`,


### PR DESCRIPTION
## Description

- Adding branding for Mermaid diagram

## Screenshot (optional)

<img width="1306" height="846" alt="image" src="https://github.com/user-attachments/assets/647cb9c0-364e-4550-a70d-0d7d6d28f40f" />

**Figure: red colors by default for our SSW Mermaid Diagram**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->