### PR TITLE
Updates rule creation link path

### DIFF
--- a/components/server/MegaMenuWrapper.tsx
+++ b/components/server/MegaMenuWrapper.tsx
@@ -65,7 +65,7 @@ const ActionButtons = () => {
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
-            href={`/${basePath}/admin/index.html#/collections/rule/~`}
+            href={`/${basePath}/admin/index.html#/collections/new/rule/~`}
             className="action-btn-link-underlined"
             aria-label="Create an SSW Rule"
           >


### PR DESCRIPTION
## Description
✏️ 
#2561 

Updates the link for creating an SSW Rule so that it now points to the correct "new rule" page in the admin interface.
