### PR TITLE
Centralize footer items on mobile + other UI adjustments

### DIFF
--- a/components/ActivityRulesView.tsx
+++ b/components/ActivityRulesView.tsx
@@ -161,7 +161,7 @@ export default function ActivityRulesView({ rules, total, recentComments, latest
           )}
         </div>
 
-        <div className="layout-sidebar min-w-0">
+        <div className="layout-sidebar min-w-0 mb-8">
           <RecentCommentsCard comments={recentComments} />
           <QuickLinksCard data={homepage?.quickLinks} />
           <WhyRulesCard data={homepage?.whyRules} />

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -32,12 +32,12 @@ export const Footer = () => {
           <GitHubButtonWrapper />
         </section>
       </div>
-      <footer className="bg-[var(--footer-background)] text-[var(--footer-foreground)] py-6 md:py-4 lg:py-2  [&_a]:no-underline text-xs">
+      <footer className="text-center bg-[var(--footer-background)] text-[var(--footer-foreground)] py-6 md:py-4 lg:py-2 [&_a]:no-underline text-xs">
         <section className="main-container">
           <div className="xl:mx-6">
             <div className="mx-6 flex flex-col-reverse md:flex-row justify-between align-middle leading-6">
               <div className="py-2">&copy; 1990-{new Date().getFullYear()} SSW. All rights reserved.</div>
-              <div className="w-full md:w-3/6 md:text-right py-2 flex max-sm:flex-col max-sm:items-start items-center max-sm:justify-start justify-center md:justify-end">
+              <div className="w-full md:w-3/6 md:text-right py-2 flex max-sm:flex-col items-center max-sm:justify-start justify-center md:justify-end">
                 <a
                   className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
                   href="https://github.com/SSWConsulting/SSW.Rules/issues"

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -33,7 +33,7 @@ export const Footer = () => {
         </section>
       </div>
       <footer className="text-center bg-[var(--footer-background)] text-[var(--footer-foreground)] py-6 md:py-4 lg:py-2 [&_a]:no-underline text-xs">
-        <section className="main-container">
+        <section className="main-container max-w-screen-xl">
           <div className="xl:mx-6">
             <div className="mx-6 flex flex-col-reverse md:flex-row justify-between align-middle leading-6">
               <div className="py-2">&copy; 1990-{new Date().getFullYear()} SSW. All rights reserved.</div>

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -39,7 +39,7 @@ export const Footer = () => {
               <div className="py-2">&copy; 1990-{new Date().getFullYear()} SSW. All rights reserved.</div>
               <div className="w-full md:w-3/4 md:text-right py-2 flex max-sm:flex-col items-center max-sm:justify-start justify-center md:justify-end">
                 <a
-                  className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
                   href="https://github.com/SSWConsulting/SSW.Rules/issues"
                   target="_blank"
                   rel="noopener noreferrer nofollow"
@@ -48,7 +48,7 @@ export const Footer = () => {
                 </a>
                 <span className="px-2 hidden sm:inline">|</span>
                 <a
-                  className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
                   href="https://www.ssw.com.au/terms-and-conditions"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -58,7 +58,7 @@ export const Footer = () => {
                 <span className="px-2 hidden sm:inline">|</span>
                 <div className="inline-flex flex-row-reverse justify-end flex-nowrap">
                   <a
-                    className="unstyled block float-right h-[25px] w-[25px] ml-2 text-white visited:text-white no-underline text-center leading-[25px]"
+                    className="unstyled block float-right h-[25px] w-[25px] ml-4 text-white hover:text-ssw-red visited:text-white no-underline text-center leading-[25px]"
                     id="tiktok-icon"
                     title="SSW on TikTok"
                     href="https://www.tiktok.com/@ssw_tv"
@@ -68,7 +68,7 @@ export const Footer = () => {
                     <FaTiktok size={24} />
                   </a>
                   <a
-                    className="unstyled block float-right h-[25px] w-[25px] ml-2 text-white visited:text-white no-underline text-center leading-[25px]"
+                    className="unstyled block float-right h-[25px] w-[25px] ml-4 text-white hover:text-ssw-red visited:text-white no-underline text-center leading-[25px]"
                     id="twitter-icon"
                     title="SSW on Twitter"
                     href="https://twitter.com/SSW_TV"
@@ -78,7 +78,7 @@ export const Footer = () => {
                     <FaXTwitter size={24} />
                   </a>
                   <a
-                    className="unstyled block float-right h-[25px] w-[25px] ml-2 text-white visited:text-white no-underline text-center leading-[25px]"
+                    className="unstyled block float-right h-[25px] w-[25px] ml-4 text-white hover:text-ssw-red visited:text-white no-underline text-center leading-[25px]"
                     id="instagram-icon"
                     title="SSW on Instagram"
                     href="https://www.instagram.com/ssw_tv"
@@ -88,7 +88,7 @@ export const Footer = () => {
                     <FaInstagram size={24} />
                   </a>
                   <a
-                    className="unstyled block float-right h-[25px] w-[25px] ml-2 text-white visited:text-white no-underline text-center leading-[25px]"
+                    className="unstyled block float-right h-[25px] w-[25px] ml-4 text-white hover:text-ssw-red visited:text-white no-underline text-center leading-[25px]"
                     id="facebook-icon"
                     title="SSW on Facebook"
                     href="https://www.facebook.com/SSW.page"
@@ -98,7 +98,7 @@ export const Footer = () => {
                     <FaFacebook size={24} />
                   </a>
                   <a
-                    className="unstyled block float-right h-[25px] w-[25px] ml-2 text-white visited:text-white no-underline text-center leading-[25px]"
+                    className="unstyled block float-right h-[25px] w-[25px] ml-4 text-white hover:text-ssw-red visited:text-white no-underline text-center leading-[25px]"
                     id="linkedin-icon"
                     title="SSW on LinkedIn"
                     href="https://www.linkedin.com/company/ssw"
@@ -108,7 +108,7 @@ export const Footer = () => {
                     <FaLinkedin size={24} />
                   </a>
                   <a
-                    className="unstyled block float-right h-[25px] w-[25px] ml-2 text-white visited:text-white no-underline text-center leading-[25px]"
+                    className="unstyled block float-right h-[25px] w-[25px] ml-4 text-white hover:text-ssw-red visited:text-white no-underline text-center leading-[25px]"
                     id="youtube-icon"
                     title="SSW on YouTube"
                     href="https://www.youtube.com/user/sswtechtalks"
@@ -125,7 +125,7 @@ export const Footer = () => {
               <div className="py-2">
                 This website is under{" "}
                 <a
-                  className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={`${pathPrefix}/rules-to-better-websites-deployment`}
                 >
                   CONSTANT CONTINUOUS DEPLOYMENT
@@ -133,7 +133,7 @@ export const Footer = () => {
                 . Last deployed {getLastDeployTime()} ago
                 {buildDate && <span title={buildDate}> on {moment(buildDate).format("MMM D, YYYY [at] HH:mm UTC")}</span>} (Build #{" "}
                 <a
-                  className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={deploymentUrl}
                   target="_blank"
                   rel="noopener noreferrer nofollow"
@@ -145,14 +145,14 @@ export const Footer = () => {
               <div className="md:text-right py-2">
                 Powered by{" "}
                 <a
-                  className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={`${pathPrefix}/rules-to-better-azure`}
                 >
                   Azure
                 </a>{" "}
                 and{" "}
                 <a
-                  className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={`${pathPrefix}/static-site-generator`}
                 >
                   {" "}

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -37,7 +37,7 @@ export const Footer = () => {
           <div className="xl:mx-6">
             <div className="mx-6 flex flex-col-reverse md:flex-row justify-between align-middle leading-6">
               <div className="py-2">&copy; 1990-{new Date().getFullYear()} SSW. All rights reserved.</div>
-              <div className="w-full md:w-3/6 md:text-right py-2 flex max-sm:flex-col items-center max-sm:justify-start justify-center md:justify-end">
+              <div className="w-full md:w-3/4 md:text-right py-2 flex max-sm:flex-col items-center max-sm:justify-start justify-center md:justify-end">
                 <a
                   className="inline-block text-white visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
                   href="https://github.com/SSWConsulting/SSW.Rules/issues"


### PR DESCRIPTION
FROM

<img width="418" height="485" alt="Screenshot 2026-04-10 at 1 21 57 PM" src="https://github.com/user-attachments/assets/0411f044-ed28-44a5-9110-3d379df648d8" />


TO

<img width="409" height="561" alt="Screenshot 2026-04-10 at 1 27 03 PM" src="https://github.com/user-attachments/assets/89487185-eb73-4501-bdcf-e4fa4332b062" />
