### PR TITLE
Fix Auth0 build error after Next.js upgrade

### DIFF
--- a/app/api/session/check/route.ts
+++ b/app/api/session/check/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth0 } from "@/lib/auth0";
+import { getAuth0 } from "@/lib/auth0";
 
 export const dynamic = "force-dynamic";
 export async function GET(req: NextRequest) {
   try {
-    const session = await auth0.getSession();
+    const session = await getAuth0().getSession();
     if (session) {
       return NextResponse.json({ isAuthenticated: true }, { status: 200 });
     }

--- a/lib/auth0.ts
+++ b/lib/auth0.ts
@@ -1,13 +1,20 @@
 import { Auth0Client } from '@auth0/nextjs-auth0/server';
 
-export const auth0 = new Auth0Client({
-    domain: process.env.AUTH0_DOMAIN!,
-    clientId: process.env.AUTH0_CLIENT_ID!,
-    clientSecret: process.env.AUTH0_CLIENT_SECRET!,
-    appBaseUrl: process.env.AUTH0_REDIRECT_URI!,
-    secret: process.env.AUTH0_SECRET!,
-    authorizationParameters: {
-        audience: process.env.AUTH0_AUDIENCE!,
-        //scope: 'openid profile email'
+let _auth0: Auth0Client | undefined;
+
+export function getAuth0(): Auth0Client {
+    if (!_auth0) {
+        _auth0 = new Auth0Client({
+            domain: process.env.AUTH0_DOMAIN!,
+            clientId: process.env.AUTH0_CLIENT_ID!,
+            clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+            appBaseUrl: process.env.AUTH0_REDIRECT_URI!,
+            secret: process.env.AUTH0_SECRET!,
+            authorizationParameters: {
+                audience: process.env.AUTH0_AUDIENCE!,
+                //scope: 'openid profile email'
+            }
+        });
     }
-})
+    return _auth0;
+}

--- a/lib/auth0.ts
+++ b/lib/auth0.ts
@@ -1,20 +1,20 @@
-import { Auth0Client } from '@auth0/nextjs-auth0/server';
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
 let _auth0: Auth0Client | undefined;
 
 export function getAuth0(): Auth0Client {
-    if (!_auth0) {
-        _auth0 = new Auth0Client({
-            domain: process.env.AUTH0_DOMAIN!,
-            clientId: process.env.AUTH0_CLIENT_ID!,
-            clientSecret: process.env.AUTH0_CLIENT_SECRET!,
-            appBaseUrl: process.env.AUTH0_REDIRECT_URI!,
-            secret: process.env.AUTH0_SECRET!,
-            authorizationParameters: {
-                audience: process.env.AUTH0_AUDIENCE!,
-                //scope: 'openid profile email'
-            }
-        });
-    }
-    return _auth0;
+  if (!_auth0) {
+    _auth0 = new Auth0Client({
+      domain: process.env.AUTH0_DOMAIN!,
+      clientId: process.env.AUTH0_CLIENT_ID!,
+      clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+      appBaseUrl: process.env.AUTH0_REDIRECT_URI!,
+      secret: process.env.AUTH0_SECRET!,
+      authorizationParameters: {
+        audience: process.env.AUTH0_AUDIENCE!,
+        //scope: 'openid profile email'
+      }
+    });
+  }
+  return _auth0;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import * as appInsights from "applicationinsights";
 import { NextRequest, NextResponse } from "next/server";
-import { auth0 } from "./lib/auth0";
+import { getAuth0 } from "./lib/auth0";
 import redirectMappingRaw from "./redirects.json";
 
 export const runtime = "nodejs";
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (pathname.startsWith("/auth") || pathname.startsWith(`${process.env.NEXT_PUBLIC_BASE_PATH}/auth`)) {
-    return auth0.middleware(request);
+    return getAuth0().middleware(request);
   }
 
   const slug = pathname.replace(/^\//, "");


### PR DESCRIPTION
This pull request refactors how the Auth0 client is initialized and accessed throughout the codebase. Instead of creating a single exported instance, it introduces a `getAuth0()` function that lazily initializes and returns a singleton Auth0 client. This change improves flexibility and can help with issues related to environment variable loading or testing.

**Auth0 Client Initialization Refactor:**

* Replaces the exported `auth0` instance in `lib/auth0.ts` with a `getAuth0()` function that lazily initializes and returns a singleton `Auth0Client`. [[1]](diffhunk://#diff-8ceefe59b0c348f016f45e2466e9d172655b216d163a86d2c7ba4f0796de4e41L3-R7) [[2]](diffhunk://#diff-8ceefe59b0c348f016f45e2466e9d172655b216d163a86d2c7ba4f0796de4e41L13-R20)

**Codebase-wide Updates to Auth0 Usage:**

* Updates imports and usage of the Auth0 client in `app/api/session/check/route.ts` and `middleware.ts` to use `getAuth0()` instead of directly referencing the exported `auth0` instance. [[1]](diffhunk://#diff-1a84483be1f6a9ba59f426cd31eb72a9f73cca8e1be45b01cd7fb31e1faf31acL2-R7) [[2]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL3-R3) [[3]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL16-R16)## Description
