### PR TITLE
Adds support for inline SVG rendering in markdown

### DIFF
--- a/components/tina-markdown/markdown-component-mapping.tsx
+++ b/components/tina-markdown/markdown-component-mapping.tsx
@@ -77,6 +77,13 @@ export const getMarkdownComponentMapping = (enableAnchors = false): Components<a
     h5: withHighlightProcessing("h5"),
     h6: withHighlightProcessing("h6"),
 
+    html_inline: ({ value }: { value: string }) => {
+      if (typeof value === "string" && value.trimStart().startsWith("<svg")) {
+        return <span dangerouslySetInnerHTML={{ __html: value }} />;
+      }
+      return <></>;
+    },
+
     blockquote: (props: any) => {
       const textWithHighlight = getTextFromContent(props);
       if (textWithHighlight) {

--- a/components/tina-markdown/markdown-component-mapping.tsx
+++ b/components/tina-markdown/markdown-component-mapping.tsx
@@ -78,10 +78,27 @@ export const getMarkdownComponentMapping = (enableAnchors = false): Components<a
     h6: withHighlightProcessing("h6"),
 
     html_inline: ({ value }: { value: string }) => {
-      if (typeof value === "string" && value.trimStart().startsWith("<svg")) {
-        return <span dangerouslySetInnerHTML={{ __html: value }} />;
+      if (typeof value !== "string") return <></>;
+      const trimmed = value.trim();
+      if (!trimmed.startsWith("<svg")) return <></>;
+
+      const lower = trimmed.toLowerCase();
+      // Reject scripts, foreignObject (embeds arbitrary HTML), and event handler attributes
+      if (
+        lower.includes("<script") ||
+        lower.includes("<foreignobject") ||
+        /\bon\w+\s*=/.test(lower) ||
+        /\bhref\s*=\s*["']?\s*javascript:/i.test(trimmed)
+      ) {
+        return <></>;
       }
-      return <></>;
+      // Reject trailing content after the closing </svg>
+      const svgCloseIndex = trimmed.lastIndexOf("</svg>");
+      if (svgCloseIndex === -1 || trimmed.slice(svgCloseIndex + 6).trim() !== "") {
+        return <></>;
+      }
+
+      return <span dangerouslySetInnerHTML={{ __html: trimmed }} />;
     },
 
     blockquote: (props: any) => {


### PR DESCRIPTION
#2569 

This pull request adds support for rendering inline SVG elements in Markdown content, with strict security checks to prevent injection of unsafe HTML or scripts. The main change is the addition of a handler for `html_inline` nodes in the Markdown component mapping, which only allows safe SVG markup to be rendered.

**Markdown rendering and security:**

* Added an `html_inline` handler to `getMarkdownComponentMapping` in `markdown-component-mapping.tsx` that renders inline SVGs only if the markup is safe—rejecting scripts, `foreignObject`, event handler attributes, `javascript:` URLs, and any content after the closing `</svg>` tag.