### PR TITLE
Adding animation on "latest rule" filter + keeping filter when navigating back on homepage

### DIFF
--- a/components/ActivityRulesView.tsx
+++ b/components/ActivityRulesView.tsx
@@ -48,8 +48,16 @@ interface ActivityRulesViewProps {
   homepage?: any;
 }
 
+function getInitialSort(): SortKey {
+  if (typeof window === "undefined") return "mostLiked";
+  const params = new URLSearchParams(window.location.search);
+  const sort = params.get("sort");
+  if (sort && SORT_OPTIONS.some((o) => o.key === sort)) return sort as SortKey;
+  return "mostLiked";
+}
+
 export default function ActivityRulesView({ rules, total, recentComments, latestRulesData, homepage }: ActivityRulesViewProps) {
-  const [sortKey, setSortKey] = useState<SortKey>("mostLiked");
+  const [sortKey, setSortKey] = useState<SortKey>(getInitialSort);
 
   const [animatingMetric, setAnimatingMetric] = useState<SortKey | null>(null);
   const [animationEpoch, setAnimationEpoch] = useState(0);

--- a/components/RuleActivityCard.tsx
+++ b/components/RuleActivityCard.tsx
@@ -44,7 +44,7 @@ function metricAnimProps(
 }
 
 export default function RuleActivityCard({ rule, rank, animatingMetric, animationEpoch = 0, activeSort }: RuleActivityCardProps) {
-  const publishDate = formatDate(rule.created ?? rule.lastUpdated);
+  const publishDate = formatDate(rule.lastUpdated ?? rule.created);
 
   const categoryLabels = rule.categories.length > 0 ? rule.categories.map((cat) => shortenCategory(cat.title)).join(", ") : null;
 
@@ -68,7 +68,7 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
             <p className="text-xs text-gray-400 m-0">
               {publishDate && (
                 <span>
-                  Published on <span className="font-medium text-gray-500">{publishDate}</span>
+                  Last updated on <span {...metricAnimProps("latestRules", animatingMetric, animationEpoch, activeSort, "inline-flex font-medium text-gray-500")}>{publishDate}</span>
                 </span>
               )}
               {publishDate && rule.authors.length > 0 && <span> by </span>}

--- a/components/RuleActivityCard.tsx
+++ b/components/RuleActivityCard.tsx
@@ -27,7 +27,7 @@ function shortenCategory(title: string): string {
   return match ? match[1] : title;
 }
 
-/** Returns { key, className } to spread onto the element that should animate. */
+/** Returns { key, className } for the element that should animate. key must be passed as a JSX prop directly, not spread. */
 function metricAnimProps(
   metric: string,
   animatingMetric: string | null | undefined,
@@ -48,6 +48,11 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
 
   const categoryLabels = rule.categories.length > 0 ? rule.categories.map((cat) => shortenCategory(cat.title)).join(", ") : null;
 
+  const dateAnim = metricAnimProps("latestRules", animatingMetric, animationEpoch, activeSort, "inline-flex font-medium text-gray-500");
+  const likedAnim = metricAnimProps("mostLiked", animatingMetric, animationEpoch, activeSort, "flex items-center gap-1 no-underline text-gray-500 transition-colors cursor-pointer");
+  const commentedAnim = metricAnimProps("mostCommented", animatingMetric, animationEpoch, activeSort, "flex items-center gap-1");
+  const lastCommentedAnim = metricAnimProps("lastCommented", animatingMetric, animationEpoch, activeSort, "flex items-center gap-1 text-gray-400 ml-auto");
+
   return (
     <Card className="mb-4 p-4">
       <div className="flex gap-1 min-w-0">
@@ -63,16 +68,16 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
             </Link>
           </h2>
 
-          {/* Author + publish date + category */}
-          {(rule.authors.length > 0 || publishDate || categoryLabels) && (
+          {/* Last updated + category */}
+          {(rule.lastUpdatedBy || publishDate || categoryLabels) && (
             <p className="text-xs text-gray-400 m-0">
               {publishDate && (
                 <span>
-                  Last updated on <span {...metricAnimProps("latestRules", animatingMetric, animationEpoch, activeSort, "inline-flex font-medium text-gray-500")}>{publishDate}</span>
+                  Last updated on <span key={dateAnim.key} className={dateAnim.className}>{publishDate}</span>
                 </span>
               )}
-              {publishDate && rule.authors.length > 0 && <span> by </span>}
-              {rule.authors.length > 0 && <span className="font-medium text-gray-500">{rule.authors.join(", ")}</span>}
+              {publishDate && rule.lastUpdatedBy && <span> by </span>}
+              {rule.lastUpdatedBy && <span className="font-medium text-gray-500">{rule.lastUpdatedBy}</span>}
               {categoryLabels && (
                 <>
                   <span> under </span>
@@ -90,13 +95,8 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
             <div className="flex items-center gap-4 text-sm text-gray-500 flex-wrap">
               {/* Thumbs up: icon + count animate together */}
               <a
-                {...metricAnimProps(
-                  "mostLiked",
-                  animatingMetric,
-                  animationEpoch,
-                  activeSort,
-                  "flex items-center gap-1 no-underline text-gray-500 transition-colors cursor-pointer"
-                )}
+                key={likedAnim.key}
+                className={likedAnim.className}
                 href={`${rule.discussionUrl}#top`}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -119,7 +119,7 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
               </a>
 
               {/* Comments: icon + count + label animate together */}
-              <span {...metricAnimProps("mostCommented", animatingMetric, animationEpoch, activeSort, "flex items-center gap-1")} title="Comments">
+              <span key={commentedAnim.key} className={commentedAnim.className} title="Comments">
                 <FaComment />
                 <span>
                   {rule.commentCount} {rule.commentCount === 1 ? "comment" : "comments"}
@@ -127,7 +127,7 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
               </span>
 
               {/* Last commented: icon + label + timestamp animate together */}
-              <span {...metricAnimProps("lastCommented", animatingMetric, animationEpoch, activeSort, "flex items-center gap-1 text-gray-400 ml-auto")}>
+              <span key={lastCommentedAnim.key} className={lastCommentedAnim.className}>
                 <RiTimeFill />
                 <span>Last commented {timeAgo(rule.lastCommentAt)}</span>
               </span>

--- a/components/RuleActivityCard.tsx
+++ b/components/RuleActivityCard.tsx
@@ -46,6 +46,8 @@ function metricAnimProps(
 export default function RuleActivityCard({ rule, rank, animatingMetric, animationEpoch = 0, activeSort }: RuleActivityCardProps) {
   const publishDate = formatDate(rule.lastUpdated ?? rule.created);
 
+  const displayBy = rule.lastUpdatedBy || rule.createdBy || (rule.authors.length > 0 ? rule.authors.join(", ") : null);
+
   const categoryLabels = rule.categories.length > 0 ? rule.categories.map((cat) => shortenCategory(cat.title)).join(", ") : null;
 
   const dateAnim = metricAnimProps("latestRules", animatingMetric, animationEpoch, activeSort, "inline-flex font-medium text-gray-500");
@@ -69,15 +71,15 @@ export default function RuleActivityCard({ rule, rank, animatingMetric, animatio
           </h2>
 
           {/* Last updated + category */}
-          {(rule.lastUpdatedBy || publishDate || categoryLabels) && (
+          {(displayBy || publishDate || categoryLabels) && (
             <p className="text-xs text-gray-400 m-0">
               {publishDate && (
                 <span>
                   Last updated on <span key={dateAnim.key} className={dateAnim.className}>{publishDate}</span>
                 </span>
               )}
-              {publishDate && rule.lastUpdatedBy && <span> by </span>}
-              {rule.lastUpdatedBy && <span className="font-medium text-gray-500">{rule.lastUpdatedBy}</span>}
+              {publishDate && displayBy && <span> by </span>}
+              {displayBy && <span className="font-medium text-gray-500">{displayBy}</span>}
               {categoryLabels && (
                 <>
                   <span> under </span>

--- a/lib/services/github/discussions.service.ts
+++ b/lib/services/github/discussions.service.ts
@@ -152,11 +152,11 @@ async function fetchDiscussions(token: string, owner: string, repoName: string):
 async function fetchRulesByGuids(
   guids: string[]
 ): Promise<
-  Map<string, { title: string; uri: string; authors: string[]; created: string | null; lastUpdated: string | null; body: any; categories: Array<{ title: string; uri: string }> }>
+  Map<string, { title: string; uri: string; authors: string[]; created: string | null; lastUpdated: string | null; lastUpdatedBy: string | null; body: any; categories: Array<{ title: string; uri: string }> }>
 > {
   const map = new Map<
     string,
-    { title: string; uri: string; authors: string[]; created: string | null; lastUpdated: string | null; body: any; categories: Array<{ title: string; uri: string }> }
+    { title: string; uri: string; authors: string[]; created: string | null; lastUpdated: string | null; lastUpdatedBy: string | null; body: any; categories: Array<{ title: string; uri: string }> }
   >();
   if (guids.length === 0) return map;
 
@@ -185,6 +185,7 @@ async function fetchRulesByGuids(
         authors,
         created: node.created ?? null,
         lastUpdated: node.lastUpdated ?? null,
+        lastUpdatedBy: (node as any).lastUpdatedBy ?? null,
         body: node.body ?? null,
         categories,
       });
@@ -253,6 +254,7 @@ export async function fetchDiscussionData(): Promise<DiscussionData> {
       authors: rule.authors,
       created: rule.created,
       lastUpdated: rule.lastUpdated,
+      lastUpdatedBy: rule.lastUpdatedBy,
       descriptionPreview: extractBodyPreview(rule.body),
       categories: rule.categories,
       thumbsUp: discussion.thumbsUp.totalCount + discussion.heart.totalCount + discussion.rocket.totalCount + discussion.hooray.totalCount,

--- a/lib/services/github/discussions.service.ts
+++ b/lib/services/github/discussions.service.ts
@@ -152,11 +152,11 @@ async function fetchDiscussions(token: string, owner: string, repoName: string):
 async function fetchRulesByGuids(
   guids: string[]
 ): Promise<
-  Map<string, { title: string; uri: string; authors: string[]; created: string | null; lastUpdated: string | null; lastUpdatedBy: string | null; body: any; categories: Array<{ title: string; uri: string }> }>
+  Map<string, { title: string; uri: string; authors: string[]; created: string | null; createdBy: string | null; lastUpdated: string | null; lastUpdatedBy: string | null; body: any; categories: Array<{ title: string; uri: string }> }>
 > {
   const map = new Map<
     string,
-    { title: string; uri: string; authors: string[]; created: string | null; lastUpdated: string | null; lastUpdatedBy: string | null; body: any; categories: Array<{ title: string; uri: string }> }
+    { title: string; uri: string; authors: string[]; created: string | null; createdBy: string | null; lastUpdated: string | null; lastUpdatedBy: string | null; body: any; categories: Array<{ title: string; uri: string }> }
   >();
   if (guids.length === 0) return map;
 
@@ -184,6 +184,7 @@ async function fetchRulesByGuids(
         uri: node.uri,
         authors,
         created: node.created ?? null,
+        createdBy: (node as any).createdBy ?? null,
         lastUpdated: node.lastUpdated ?? null,
         lastUpdatedBy: (node as any).lastUpdatedBy ?? null,
         body: node.body ?? null,
@@ -253,6 +254,7 @@ export async function fetchDiscussionData(): Promise<DiscussionData> {
       commentCount: discussion.comments.totalCount,
       authors: rule.authors,
       created: rule.created,
+      createdBy: rule.createdBy,
       lastUpdated: rule.lastUpdated,
       lastUpdatedBy: rule.lastUpdatedBy,
       descriptionPreview: extractBodyPreview(rule.body),

--- a/lib/services/rules/rules.service.ts
+++ b/lib/services/rules/rules.service.ts
@@ -33,6 +33,7 @@ async function fetchActivityLatestRulesData(size: number = 200): Promise<Activit
     commentCount: 0,
     authors: r.authors?.map((a: any) => a.title).filter(Boolean) || [],
     created: r.created || null,
+    createdBy: r.createdBy || null,
     lastUpdated: r.lastUpdated || null,
     lastUpdatedBy: r.lastUpdatedBy || null,
     descriptionPreview: extractBodyPreview(r.body),

--- a/lib/services/rules/rules.service.ts
+++ b/lib/services/rules/rules.service.ts
@@ -34,6 +34,7 @@ async function fetchActivityLatestRulesData(size: number = 200): Promise<Activit
     authors: r.authors?.map((a: any) => a.title).filter(Boolean) || [],
     created: r.created || null,
     lastUpdated: r.lastUpdated || null,
+    lastUpdatedBy: r.lastUpdatedBy || null,
     descriptionPreview: extractBodyPreview(r.body),
     categories: (r.categories || [])
       .map((c: any) => c?.category)

--- a/models/ActivityRule.ts
+++ b/models/ActivityRule.ts
@@ -12,6 +12,7 @@ export interface ActivityRule {
   authors: string[];
   created: string | null;
   lastUpdated: string | null;
+  lastUpdatedBy: string | null;
   descriptionPreview: string;
   categories: ActivityRuleCategory[];
   thumbsUp: number;

--- a/models/ActivityRule.ts
+++ b/models/ActivityRule.ts
@@ -11,6 +11,7 @@ export interface ActivityRule {
   commentCount: number;
   authors: string[];
   created: string | null;
+  createdBy: string | null;
   lastUpdated: string | null;
   lastUpdatedBy: string | null;
   descriptionPreview: string;

--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -7,6 +7,7 @@ query activityLatestRulesQuery($size: Float) {
         uri
         body
         created
+        createdBy
         lastUpdated
         lastUpdatedBy
         authors {
@@ -138,6 +139,7 @@ query rulesByGuidQuery($guids: [String!]!) {
         uri
         body
         created
+        createdBy
         lastUpdated
         lastUpdatedBy
         authors {

--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -139,6 +139,7 @@ query rulesByGuidQuery($guids: [String!]!) {
         body
         created
         lastUpdated
+        lastUpdatedBy
         authors {
           title
         }


### PR DESCRIPTION
This pull request introduces improvements to the sorting and display logic for activity rules and rule cards. The main changes include initializing the sort order from the URL, updating the logic for displaying publish dates, and enhancing the animation and labeling of rule metadata.

**Sorting and Initialization:**
- [`components/ActivityRulesView.tsx`](diffhunk://#diff-1c5fa87340b53f27fa26cea5b01262dc301b2ad74d1f52307313a086aedced3fR51-R60): The initial sort key for activity rules is now determined by parsing the `sort` parameter from the URL, defaulting to `"mostLiked"` if not present or invalid. This allows for deep-linking and bookmarking with specific sort orders.

**Rule Metadata Display:**
- [`components/RuleActivityCard.tsx`](diffhunk://#diff-0ea6531ce4318445354b35e266c800daabcbbdebcdd4ec62ee60feaaef2f90c0L47-R47): The logic for displaying the publish date has been updated to prefer `lastUpdated` over `created`, ensuring users see the most recent relevant date.
- [`components/RuleActivityCard.tsx`](diffhunk://#diff-0ea6531ce4318445354b35e266c800daabcbbdebcdd4ec62ee60feaaef2f90c0L71-R71): The publish date label has been changed from "Published on" to "Last updated on", and now includes animation props for improved UI feedback when sorting by latest rules.

<img width="1280" height="720" alt="D02F8E71-C815-4710-BE0E-B498C8412CBF" src="https://github.com/user-attachments/assets/0022df43-2536-417f-988f-4a5b294db663" />
