### PR TITLE
💄 Updates RuleSelector to improve archived rule display

### DIFF
--- a/tina/fields/RuleSelector.tsx
+++ b/tina/fields/RuleSelector.tsx
@@ -209,7 +209,7 @@ export const RuleSelector: React.FC<any> = ({ input }) => {
                                   <div className="flex-1 min-w-0 overflow-hidden">
                                     <div className="flex items-start gap-2">
                                       <span
-                                        className={`font-medium text-sm leading-5 whitespace-normal break-words line-clamp-2 flex-1 min-w-0 ${rule.isArchived ? "opacity-50 text-gray-900" : "text-gray-900"}`}
+                                        className={`font-medium text-gray-900 text-sm leading-5 whitespace-normal break-words line-clamp-2 flex-1 min-w-0 ${rule.isArchived ? "opacity-50" : ""}`}
                                         title={rule.title || rule.uri}
                                       >
                                         {rule.title || rule.uri}

--- a/tina/fields/RuleSelector.tsx
+++ b/tina/fields/RuleSelector.tsx
@@ -2,7 +2,7 @@
 
 import { Popover, PopoverButton, PopoverPanel, Transition } from "@headlessui/react";
 import React, { useEffect, useMemo, useState } from "react";
-import { BiChevronDown, BiSearch } from "react-icons/bi";
+import { BiChevronDown, BiSearch, BiSolidError } from "react-icons/bi";
 
 interface Rule {
   title: string;
@@ -207,15 +207,16 @@ export const RuleSelector: React.FC<any> = ({ input }) => {
                               >
                                 <div className="flex items-center justify-between w-full gap-3">
                                   <div className="flex-1 min-w-0 overflow-hidden">
-                                    <div className="flex items-center gap-2">
+                                    <div className="flex items-start gap-2">
                                       <span
-                                        className="font-medium text-gray-900 text-sm leading-5 whitespace-normal break-words line-clamp-2 flex-1 min-w-0"
+                                        className={`font-medium text-sm leading-5 whitespace-normal break-words line-clamp-2 flex-1 min-w-0 ${rule.isArchived ? "opacity-50 text-gray-900" : "text-gray-900"}`}
                                         title={rule.title || rule.uri}
                                       >
                                         {rule.title || rule.uri}
                                       </span>
                                       {rule.isArchived && (
-                                        <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-red-600 text-white">
+                                        <span className="shrink-0 mt-1 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium bg-red-50 border border-red-200 text-[#cc4141]">
+                                          <BiSolidError className="h-3 w-3 shrink-0" aria-hidden="true" />
                                           Archived
                                         </span>
                                       )}


### PR DESCRIPTION
#2573
This pull request makes visual improvements to the `RuleSelector` component, specifically enhancing how archived rules are displayed. The most important changes are:

**UI/UX improvements for archived rules:**

* The archived badge is now styled with a lighter red background, a border, and uses a more accessible text color for better visibility.
* An error icon (`BiSolidError`) is added next to the "Archived" label to visually indicate the archived status. [[1]](diffhunk://#diff-24cdb4b1b62a7a686fade16a1391c56feca698792f3ec1dbe364a2732997d6e9L5-R5) [[2]](diffhunk://#diff-24cdb4b1b62a7a686fade16a1391c56feca698792f3ec1dbe364a2732997d6e9L210-R219)
* The rule title for archived rules is shown with reduced opacity, making it clear which rules are archived.

These changes improve the clarity and accessibility of the archived rule indicator in the UI.

<img width="1551" height="1400" alt="image" src="https://github.com/user-attachments/assets/ad1f03eb-64a4-43d0-8808-036be703a2c1" />
