### PR TITLE
Add content freshness check and auto-retrigger for deployments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -284,14 +284,14 @@ jobs:
             - name: Retrigger production deployment with fresh content
               if: steps.freshness_check.outputs.stale == 'true'
               run: |
-                  BRANCH="${{ github.event.inputs.branch_name || github.ref_name }}"
-                  echo "🔄 Triggering fresh production deployment from branch: $BRANCH"
+                  echo "🔄 Triggering fresh production deployment from: ${{ github.ref_name }}"
 
                   gh workflow run build-and-deploy.yml \
                     --repo "${{ github.repository }}" \
-                    --ref "$BRANCH" \
+                    --ref "${{ github.ref_name }}" \
                     -f environment=production \
-                    -f branch_name="$BRANCH"
+                    -f branch_name="${{ github.event.inputs.branch_name }}" \
+                    -f tina_branch="${{ github.event.inputs.tina_branch }}"
 
                   echo "✅ Retrigger dispatched — the new run will build with the latest content"
               env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -263,8 +263,13 @@ jobs:
                   echo "Content branch used: $CONTENT_BRANCH"
                   echo "Content SHA at build time: $BUILT_SHA"
 
-                  CURRENT_SHA=$(gh api "repos/SSWConsulting/SSW.Rules.Content/commits/$CONTENT_BRANCH" \
-                    --jq '.sha')
+                  CURRENT_SHA=$(git ls-remote "https://github.com/SSWConsulting/SSW.Rules.Content.git" \
+                    "refs/heads/$CONTENT_BRANCH" | awk '{print $1}')
+
+                  if [ -z "$CURRENT_SHA" ]; then
+                    echo "❌ Could not resolve current SHA for branch '$CONTENT_BRANCH' — ls-remote returned nothing"
+                    exit 1
+                  fi
 
                   echo "Content SHA now:           $CURRENT_SHA"
 
@@ -275,8 +280,6 @@ jobs:
                     echo "✅ Content is up to date — no retrigger needed"
                     echo "stale=false" >> $GITHUB_OUTPUT
                   fi
-              env:
-                  GH_TOKEN: ${{ github.token }}
 
             - name: Retrigger production deployment with fresh content
               if: steps.freshness_check.outputs.stale == 'true'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -245,13 +245,6 @@ jobs:
         with:
             sitemap_url: https://www.ssw.com.au/rules/sitemap-index-0.xml
 
-    # ============================================================================
-    # POST-DEPLOYMENT CONTENT FRESHNESS CHECK
-    # Compares the SSW.Rules.Content SHA used during the build against the current
-    # HEAD of that branch. If new commits were merged during the ~20-minute build
-    # window, a fresh production deployment is triggered automatically so the live
-    # site is never left with stale content until the next scheduled run.
-    # ============================================================================
     check-content-freshness:
         name: Check Content Freshness & Retrigger if Stale
         if: github.event.inputs.environment == 'production'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -244,3 +244,59 @@ jobs:
         uses: ./.github/workflows/crawl-sitemap.yml
         with:
             sitemap_url: https://www.ssw.com.au/rules/sitemap-index-0.xml
+
+    # ============================================================================
+    # POST-DEPLOYMENT CONTENT FRESHNESS CHECK
+    # Compares the SSW.Rules.Content SHA used during the build against the current
+    # HEAD of that branch. If new commits were merged during the ~20-minute build
+    # window, a fresh production deployment is triggered automatically so the live
+    # site is never left with stale content until the next scheduled run.
+    # ============================================================================
+    check-content-freshness:
+        name: Check Content Freshness & Retrigger if Stale
+        if: github.event.inputs.environment == 'production'
+        needs: [build, deploy]
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+            contents: read
+        steps:
+            - name: Compare content SHA used in build vs current HEAD
+              id: freshness_check
+              run: |
+                  BUILT_SHA="${{ needs.build.outputs.content_sha }}"
+                  CONTENT_BRANCH="${{ needs.build.outputs.content_branch }}"
+
+                  echo "Content branch used: $CONTENT_BRANCH"
+                  echo "Content SHA at build time: $BUILT_SHA"
+
+                  CURRENT_SHA=$(gh api "repos/SSWConsulting/SSW.Rules.Content/commits/$CONTENT_BRANCH" \
+                    --jq '.sha')
+
+                  echo "Content SHA now:           $CURRENT_SHA"
+
+                  if [ "$BUILT_SHA" != "$CURRENT_SHA" ]; then
+                    echo "⚠️ SSW.Rules.Content changed during deployment — site was built from $BUILT_SHA but HEAD is now $CURRENT_SHA"
+                    echo "stale=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "✅ Content is up to date — no retrigger needed"
+                    echo "stale=false" >> $GITHUB_OUTPUT
+                  fi
+              env:
+                  GH_TOKEN: ${{ github.token }}
+
+            - name: Retrigger production deployment with fresh content
+              if: steps.freshness_check.outputs.stale == 'true'
+              run: |
+                  BRANCH="${{ github.event.inputs.branch_name || github.ref_name }}"
+                  echo "🔄 Triggering fresh production deployment from branch: $BRANCH"
+
+                  gh workflow run build-and-deploy.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref "$BRANCH" \
+                    -f environment=production \
+                    -f branch_name="$BRANCH"
+
+                  echo "✅ Retrigger dispatched — the new run will build with the latest content"
+              env:
+                  GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -116,6 +116,12 @@ on:
       deployment_url:
         description: "Deployment URL"
         value: ${{ jobs.build-and-push.outputs.deployment_url }}
+      content_sha:
+        description: "SSW.Rules.Content commit SHA used during this build"
+        value: ${{ jobs.build-and-push.outputs.content_sha }}
+      content_branch:
+        description: "SSW.Rules.Content branch used during this build"
+        value: ${{ jobs.build-and-push.outputs.content_branch }}
 
 defaults:
   run:
@@ -137,6 +143,8 @@ jobs:
       commit_hash: ${{ env.COMMIT_HASH }}
       version_deployed: ${{ env.VERSION_DEPLOYED }}
       deployment_url: ${{ env.DEPLOYMENT_URL }}
+      content_sha: ${{ steps.capture_content_sha.outputs.content_sha }}
+      content_branch: ${{ steps.resolve_content_branch.outputs.content_branch }}
     steps:
       # ────────────────────────────── BUILD INFO ─────────────────────────────
       - name: Generate build information
@@ -251,6 +259,14 @@ jobs:
           path: content-temp
           fetch-depth: 0
           lfs: true
+
+      - name: Capture SSW.Rules.Content commit SHA
+        id: capture_content_sha
+        run: |
+          CONTENT_SHA=$(git -C content-temp rev-parse HEAD)
+          echo "content_sha=$CONTENT_SHA" >> $GITHUB_OUTPUT
+          echo "SSW.Rules.Content SHA at build time: $CONTENT_SHA"
+          echo "SSW.Rules.Content branch: ${{ steps.resolve_content_branch.outputs.content_branch }}"
 
       # ────────────────────────────── PYTHON + MAPPING FILES ────────────────
       - name: Setup Python


### PR DESCRIPTION
Relates to #2457 

This pull request introduces a post-deployment content freshness check to the deployment workflow, ensuring that the live site always reflects the latest content from the `SSW.Rules.Content` repository. It also updates the build artifact workflow to capture and expose the content SHA and branch used during the build, which are leveraged by the new freshness check. The main changes are grouped below:

**Deployment Workflow Enhancements:**

* Added a `check-content-freshness` job to `.github/workflows/build-and-deploy.yml` that compares the content SHA used at build time with the current HEAD of the content branch. If new commits are detected during the build/deploy window, the workflow automatically retriggers a fresh production deployment to avoid serving stale content.

**Build Artifact Workflow Updates:**

* Exposed `content_sha` and `content_branch` as outputs in the `build-artifacts.yml` workflow, making them available for downstream jobs and workflows.
* Passed the captured `content_sha` and `content_branch` as outputs from the `build-and-push` job in `build-artifacts.yml`.
* Added a step to capture the `SSW.Rules.Content` commit SHA at build time, making this information available for the freshness check in the deployment workflow.