### PR TITLE
Update build command to target --content=local

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "pnpm tinacms dev -c \"next dev --turbopack\"",
-    "build": "tinacms build && next build",
+    "build": "tinacms build --content=local && next build",
     "generate:archived-rules": "node ./scripts/generate-archived-rules.js",
     "generate:people-latest-rules": "node ./scripts/generate-people-latest-rules.js",
     "postbuild": "npm run -s generate:archived-rules && next-sitemap",


### PR DESCRIPTION
Updates the TinaCloud build command to target the new --content=local flag. This ensures we aren't hammering the TinaCloud api with ~4000 calls on each build. 

The flag itself: 

* Generate the **production** TinaCMS client (so the deployed site still talks to TinaCloud at runtime)
* Make **zero** TinaCloud Content API requests during the build