### PR TITLE
#2361 - Improve search field to look also into the content

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -636,6 +636,7 @@ jobs:
           NEXT_PUBLIC_GITHUB_REPO: ${{ vars.NEXT_PUBLIC_GITHUB_REPO }}
         run: pnpm tinacms search-index
 
+          
       - name: Install Algolia Python dependencies
         run: pip install pyyaml "algoliasearch>=3,<4"
 
@@ -646,3 +647,13 @@ jobs:
           NEXT_PUBLIC_ALGOLIA_ADMIN_KEY: ${{ secrets.NEXT_PUBLIC_ALGOLIA_ADMIN_KEY }}
           NEXT_PUBLIC_ALGOLIA_INDEX_NAME: ${{ inputs.NEXT_PUBLIC_ALGOLIA_INDEX_NAME }}
         run: python algolia_sync.py
+        
+      - name: Patch rule body content in Algolia index
+        env:
+          NEXT_PUBLIC_ALGOLIA_APP_ID: ${{ secrets.NEXT_PUBLIC_ALGOLIA_APP_ID }}
+          NEXT_PUBLIC_ALGOLIA_ADMIN_KEY: ${{ secrets.NEXT_PUBLIC_ALGOLIA_ADMIN_KEY }}
+          NEXT_PUBLIC_ALGOLIA_INDEX_NAME: ${{ secrets.NEXT_PUBLIC_ALGOLIA_INDEX_NAME }}
+        run: |
+          cd content/scripts/tina-migration/algolia-indexer
+          npm install
+          node update_algolia_index.js

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -95,17 +95,7 @@ export async function POST(request: NextRequest) {
     }
 
     const client = algoliasearch(appId, apiKey);
-
-    // Inject snippet and highlight settings so results include content snippets
-    const enrichedRequests = requests.map((req: any) => ({
-      ...req,
-      attributesToSnippet: ["content:30"],
-      attributesToHighlight: ["title", "content"],
-      highlightPreTag: "<mark>",
-      highlightPostTag: "</mark>",
-    }));
-
-    const result = await client.search(enrichedRequests);
+    const result = await client.search(requests);
 
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -95,7 +95,17 @@ export async function POST(request: NextRequest) {
     }
 
     const client = algoliasearch(appId, apiKey);
-    const result = await client.search(requests);
+
+    // Inject snippet and highlight settings so results include content snippets
+    const enrichedRequests = requests.map((req: any) => ({
+      ...req,
+      attributesToSnippet: ["content:30"],
+      attributesToHighlight: ["title", "content"],
+      highlightPreTag: "<mark>",
+      highlightPostTag: "</mark>",
+    }));
+
+    const result = await client.search(enrichedRequests);
 
     return NextResponse.json(result);
   } catch (error) {

--- a/app/search/client-page.tsx
+++ b/app/search/client-page.tsx
@@ -22,6 +22,15 @@ interface SearchResult {
   objectID: string;
   title: string;
   slug: string;
+  _snippetResult?: {
+    content?: { value: string; matchLevel: string };
+    [key: string]: any;
+  };
+  _highlightResult?: {
+    title?: { value: string; matchLevel: string };
+    content?: { value: string; matchLevel: string };
+    [key: string]: any;
+  };
   [key: string]: any;
 }
 
@@ -163,6 +172,11 @@ export default function RulesSearchClientPage({ ruleCount, latestRulesByUpdated 
                     lastUpdated={result.lastUpdated ?? result.created ?? null}
                     index={index}
                     authorUrl={getAuthorUrl(result)}
+                    snippet={
+                      result._snippetResult?.content?.matchLevel !== "none"
+                        ? result._snippetResult?.content?.value
+                        : null
+                    }
                   />
                 ))}
               </div>

--- a/components/RuleCard.tsx
+++ b/components/RuleCard.tsx
@@ -11,6 +11,7 @@ interface RuleCardProps {
   index?: number;
   authorUrl?: string | null;
   skeletonMeta?: boolean;
+  snippet?: string | null;
 }
 
 function isHttpUrl(value?: string | null) {
@@ -18,7 +19,7 @@ function isHttpUrl(value?: string | null) {
   return /^https?:\/\//i.test(value.trim());
 }
 
-export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl, skeletonMeta }: RuleCardProps) {
+export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl, skeletonMeta, snippet }: RuleCardProps) {
   const showLink = !skeletonMeta && isHttpUrl(authorUrl) && (lastUpdatedBy || "Unknown") !== "Unknown";
 
   return (
@@ -30,6 +31,13 @@ export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, inde
           <Link href={`/${slug}`} className="no-underline">
             <h2 className="m-0 mb-2 text-2xl max-sm:text-lg hover:text-ssw-red">{title}</h2>
           </Link>
+
+          {snippet && (
+            <p
+              className="m-0 mb-2 text-sm text-gray-600"
+              dangerouslySetInnerHTML={{ __html: snippet }}
+            />
+          )}
 
           {skeletonMeta ? (
             <div className="flex items-center gap-4 animate-pulse">

--- a/components/RuleCard.tsx
+++ b/components/RuleCard.tsx
@@ -11,6 +11,7 @@ interface RuleCardProps {
   index?: number;
   authorUrl?: string | null;
   skeletonMeta?: boolean;
+  snippet?: string | null;
 }
 
 function isHttpUrl(value?: string | null) {
@@ -18,7 +19,7 @@ function isHttpUrl(value?: string | null) {
   return /^https?:\/\//i.test(value.trim());
 }
 
-export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl, skeletonMeta }: RuleCardProps) {
+export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl, skeletonMeta, snippet }: RuleCardProps) {
   const showLink = !skeletonMeta && isHttpUrl(authorUrl) && (lastUpdatedBy || "Unknown") !== "Unknown";
 
   return (
@@ -30,6 +31,13 @@ export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, inde
           <Link href={`/${slug}`} className="no-underline">
             <h2 className="m-0 mb-2 text-2xl max-sm:text-lg hover:text-ssw-red">{title}</h2>
           </Link>
+
+          {snippet && (
+            <p
+              className="m-0 mb-2 text-sm text-gray-600 line-clamp-2 [&_mark]:bg-yellow-200 [&_mark]:rounded-sm [&_mark]:px-0.5"
+              dangerouslySetInnerHTML={{ __html: `…${snippet}…` }}
+            />
+          )}
 
           {skeletonMeta ? (
             <div className="flex items-center gap-4 animate-pulse">

--- a/components/RuleCard.tsx
+++ b/components/RuleCard.tsx
@@ -11,7 +11,6 @@ interface RuleCardProps {
   index?: number;
   authorUrl?: string | null;
   skeletonMeta?: boolean;
-  snippet?: string | null;
 }
 
 function isHttpUrl(value?: string | null) {
@@ -19,7 +18,7 @@ function isHttpUrl(value?: string | null) {
   return /^https?:\/\//i.test(value.trim());
 }
 
-export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl, skeletonMeta, snippet }: RuleCardProps) {
+export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, index, authorUrl, skeletonMeta }: RuleCardProps) {
   const showLink = !skeletonMeta && isHttpUrl(authorUrl) && (lastUpdatedBy || "Unknown") !== "Unknown";
 
   return (
@@ -31,13 +30,6 @@ export default function RuleCard({ title, slug, lastUpdatedBy, lastUpdated, inde
           <Link href={`/${slug}`} className="no-underline">
             <h2 className="m-0 mb-2 text-2xl max-sm:text-lg hover:text-ssw-red">{title}</h2>
           </Link>
-
-          {snippet && (
-            <p
-              className="m-0 mb-2 text-sm text-gray-600 line-clamp-2 [&_mark]:bg-yellow-200 [&_mark]:rounded-sm [&_mark]:px-0.5"
-              dangerouslySetInnerHTML={{ __html: `…${snippet}…` }}
-            />
-          )}
 
           {skeletonMeta ? (
             <div className="flex items-center gap-4 animate-pulse">

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -11,6 +11,15 @@ interface SearchResult {
   objectID: string;
   title: string;
   slug: string;
+  _snippetResult?: {
+    content?: { value: string; matchLevel: string };
+    [key: string]: any;
+  };
+  _highlightResult?: {
+    title?: { value: string; matchLevel: string };
+    content?: { value: string; matchLevel: string };
+    [key: string]: any;
+  };
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Description

PBI - https://github.com/SSWConsulting/SSW.Rules/issues/2361
Related PR - https://github.com/SSWConsulting/SSW.Rules.Content/pull/12296

**Note:** 

- I had to update Algolia index shape (with content for instance)
- I had to limit the content size so it would fit within the indexing JSON file's size limit due to limitation of our Algolia free plan.
Most of the content for each file are in it though, but for very large rule, we could have a limitation

## Screenshot (optional)


<img width="1694" height="1347" alt="Image" src="https://github.com/user-attachments/assets/284f18d5-0285-43cb-88bc-6a512558c2f9" />

**Figure: now the search is looking for content and also put some highlights**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->