### PR TITLE
📦 Upgrade TinaCMS to 3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@tinacms/cli": "2.3.0",
+    "@tinacms/cli": "2.3.1",
     "@types/jest": "^30.0.0",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.19.3",
@@ -91,7 +91,7 @@
     "svg-react-loader": "^0.4.6",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
-    "tinacms": "3.8.0",
+    "tinacms": "3.8.1",
     "tw-animate-css": "^1.2.4",
     "unplugin-info": "^1.2.4",
     "usehooks-ts": "^3.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^4.1.18
         version: 4.2.4
       tinacms:
-        specifier: 3.8.0
-        version: 3.8.0(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))
+        specifier: 3.8.1
+        version: 3.8.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))
       tw-animate-css:
         specifier: ^1.2.4
         version: 1.4.0
@@ -193,8 +193,8 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@tinacms/cli':
-        specifier: 2.3.0
-        version: 2.3.0(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@3.30.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yaml@2.8.3)
+        specifier: 2.3.1
+        version: 2.3.1(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@3.30.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yaml@2.8.3)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -3640,8 +3640,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tinacms/app@2.4.7':
-    resolution: {integrity: sha512-jyuIuYtifvkcEto+7x2OzzXDVHyAGZ+mtJOiVwwa/CDSqQOO+ZK59Heyz10G3D5D85R3DEprm2R/7E8MCsHBYA==}
+  '@tinacms/app@2.4.8':
+    resolution: {integrity: sha512-Kwg9Et5vOyAZmkFrnXB+qfi4w2GioF0OVCgrWFugjDwBMZOEYxRC2qyYJJfVKNfoFr3TisZooJdszLdfA3YQMQ==}
     peerDependencies:
       react: '>=18.3.1 <20.0.0'
       react-dom: '>=18.3.1 <20.0.0'
@@ -3649,15 +3649,15 @@ packages:
   '@tinacms/bridge@0.2.0':
     resolution: {integrity: sha512-WSEhaXVtuP/JtGHfWvVTpb+rXEgSiE7Gcx5Hq0q3ajcBClRcV2OeCheTjAnkIRXygKiNvVRmywDTq0MHoJNu9A==}
 
-  '@tinacms/cli@2.3.0':
-    resolution: {integrity: sha512-qi/fsP6iaYOML3W93quxj46bGYMnMW2I+f7FpUL/BreRvU/x2QKB9zUs8pOlju48LyXjA7du9Nt2hAxAVegteA==}
+  '@tinacms/cli@2.3.1':
+    resolution: {integrity: sha512-FCNpWzbNR0QLqt08tZhwo+prx+RDMHmQISiD+0u5UCBe1bwBGbnrCP7S12qXSxJSdz3L3VEDthHasOQFqwZblg==}
     hasBin: true
     peerDependencies:
       react: '>=18.3.1 <20.0.0'
       react-dom: '>=18.3.1 <20.0.0'
 
-  '@tinacms/graphql@2.4.0':
-    resolution: {integrity: sha512-Oy6ePRM1Ee0F9HkLsFAjS3HOQTKGw/IdnQRPFfb0Pp6vH2iczSntgwDjwPn0ZLHDRU7LJ0dkxKviWdCRZZuB7A==}
+  '@tinacms/graphql@2.4.1':
+    resolution: {integrity: sha512-BVwEJ/ER3vQWqWgk/3lTzepMUeRLyBtYFtT/vcii5e38Pcp6sBJa3YX5OM2tmpiAwCIyiYS6+oIJpg6n0/CwGQ==}
 
   '@tinacms/mdx@2.1.4':
     resolution: {integrity: sha512-bHHfy/63Uj4eR+WIIgfUAqi/22EYcRs0rH69PECnrjhTbAuLcTCoHTRXl+drT+DQsg1Xwme3ifaiMWAogfuVaw==}
@@ -3673,8 +3673,8 @@ packages:
       react: '>=16.14.0'
       yup: ^1.0.0
 
-  '@tinacms/search@1.2.14':
-    resolution: {integrity: sha512-p2eiry3XK1vATu3pk3d8UqQ9n7tHl5qNQr+8AHT0JXD16J4ehx35/nMqLwtpBkgm6IOuvmmOtMwh+uK7w78PPQ==}
+  '@tinacms/search@1.2.15':
+    resolution: {integrity: sha512-OjqTYJzFpXV3V+xNvfNTi7iUuRSdjStAKAI3LhEF0yk3sZFA9DHQu0D6KjKO5FcTHQLCT2m2TQRL5Cvq5NtDzQ==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -8370,8 +8370,8 @@ packages:
   tiktok-video-element@0.1.2:
     resolution: {integrity: sha512-w6TboLm236XJKKiIXIhCbYCnUxbixBbaAoty0etaEAZ/2kHkVIdfZdv2oouMU/HGMsWCHI/VjQ3wU3MJ+s192Q==}
 
-  tinacms@3.8.0:
-    resolution: {integrity: sha512-isGM10XdRWPi8LCoSHv3etDPhTLlwJ/jsvGNq4Z1AsqKtr+tazaLszH/iFnrgugf9r8JjvPin7z667P3+U0Jng==}
+  tinacms@3.8.1:
+    resolution: {integrity: sha512-XO5adVK0O5yMjgxC8jOoZhe8VoXuHIhI+Q+bAoi7peHUZ9PEe+5GYyfO5R9rKPk1CO1l3ir4TyhyH4rrFWbBRQ==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -12964,7 +12964,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tinacms/app@2.4.7(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yup@1.7.1)':
+  '@tinacms/app@2.4.8(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yup@1.7.1)':
     dependencies:
       '@graphiql/toolkit': 0.8.4(@types/node@22.19.17)(graphql@15.8.0)
       '@headlessui/react': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -12978,7 +12978,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-router-dom: 6.3.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      tinacms: 3.8.0(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))
+      tinacms: 3.8.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))
       typescript: 5.9.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13002,7 +13002,7 @@ snapshots:
 
   '@tinacms/bridge@0.2.0': {}
 
-  '@tinacms/cli@2.3.0(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@3.30.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yaml@2.8.3)':
+  '@tinacms/cli@2.3.1(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@3.30.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yaml@2.8.3)':
     dependencies:
       '@graphql-codegen/core': 2.6.8(graphql@15.8.0)
       '@graphql-codegen/plugin-helpers': 7.0.1(graphql@15.8.0)
@@ -13017,11 +13017,11 @@ snapshots:
       '@tailwindcss/aspect-ratio': 0.4.2(tailwindcss@3.4.19(yaml@2.8.3))
       '@tailwindcss/container-queries': 0.1.1(tailwindcss@3.4.19(yaml@2.8.3))
       '@tailwindcss/typography': 0.5.19(tailwindcss@3.4.19(yaml@2.8.3))
-      '@tinacms/app': 2.4.7(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yup@1.7.1)
-      '@tinacms/graphql': 2.4.0(react@19.2.5)(typescript@5.9.3)
+      '@tinacms/app': 2.4.8(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.2.5))(yup@1.7.1)
+      '@tinacms/graphql': 2.4.1(react@19.2.5)(typescript@5.9.3)
       '@tinacms/metrics': 2.1.0(fs-extra@11.3.4)
       '@tinacms/schema-tools': 2.7.4(react@19.2.5)(yup@1.7.1)
-      '@tinacms/search': 1.2.14(abstract-level@1.0.4)(react@19.2.5)(sucrase@3.35.1)(typescript@5.9.3)(yup@1.7.1)
+      '@tinacms/search': 1.2.15(abstract-level@1.0.4)(react@19.2.5)(sucrase@3.35.1)(typescript@5.9.3)(yup@1.7.1)
       '@vitejs/plugin-react': 3.1.0(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0))
       altair-express-middleware: 7.3.6
       async-lock: 1.4.1
@@ -13050,7 +13050,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       readable-stream: 4.7.0
       tailwindcss: 3.4.19(yaml@2.8.3)
-      tinacms: 3.8.0(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))
+      tinacms: 3.8.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5))
       typanion: 3.13.0
       typescript: 5.9.3
       vite: 4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)
@@ -13084,7 +13084,7 @@ snapshots:
       - use-sync-external-store
       - yaml
 
-  '@tinacms/graphql@2.4.0(react@19.2.5)(typescript@5.9.3)':
+  '@tinacms/graphql@2.4.1(react@19.2.5)(typescript@5.9.3)':
     dependencies:
       '@iarna/toml': 2.2.5
       '@tinacms/mdx': 2.1.4(react@19.2.5)(typescript@5.9.3)(yup@1.7.1)
@@ -13161,9 +13161,9 @@ snapshots:
       yup: 1.7.1
       zod: 3.25.76
 
-  '@tinacms/search@1.2.14(abstract-level@1.0.4)(react@19.2.5)(sucrase@3.35.1)(typescript@5.9.3)(yup@1.7.1)':
+  '@tinacms/search@1.2.15(abstract-level@1.0.4)(react@19.2.5)(sucrase@3.35.1)(typescript@5.9.3)(yup@1.7.1)':
     dependencies:
-      '@tinacms/graphql': 2.4.0(react@19.2.5)(typescript@5.9.3)
+      '@tinacms/graphql': 2.4.1(react@19.2.5)(typescript@5.9.3)
       '@tinacms/schema-tools': 2.7.4(react@19.2.5)(yup@1.7.1)
       memory-level: 1.0.0
       search-index: 4.0.0(abstract-level@1.0.4)
@@ -18829,7 +18829,7 @@ snapshots:
 
   tiktok-video-element@0.1.2: {}
 
-  tinacms@3.8.0(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5)):
+  tinacms@3.8.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@22.19.17)(@types/react@19.2.14)(abstract-level@1.0.4)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.5)):
     dependencies:
       '@ariakit/react': 0.4.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18855,7 +18855,7 @@ snapshots:
       '@tinacms/bridge': 0.2.0
       '@tinacms/mdx': 2.1.4(react@19.2.5)(typescript@5.9.3)(yup@1.7.1)
       '@tinacms/schema-tools': 2.7.4(react@19.2.5)(yup@1.7.1)
-      '@tinacms/search': 1.2.14(abstract-level@1.0.4)(react@19.2.5)(sucrase@3.35.1)(typescript@5.9.3)(yup@1.7.1)
+      '@tinacms/search': 1.2.15(abstract-level@1.0.4)(react@19.2.5)(sucrase@3.35.1)(typescript@5.9.3)(yup@1.7.1)
       '@udecode/cmdk': 0.2.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@udecode/cn': 48.0.3(@types/react@19.2.14)(class-variance-authority@0.7.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwind-merge@2.6.1)
       '@udecode/plate': 48.0.5(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.5))


### PR DESCRIPTION
Patch bumps for TinaCMS dependencies.

Dependency updates:

* Upgraded `@tinacms/cli` from `2.3.0` to `2.3.1`
* Upgraded `tinacms` from `3.8.0` to `3.8.1`

## Test plan

- [x] `pnpm install` regenerates lockfile cleanly (only Tina-scoped changes)
- [x] `pnpm tinacms build --local --skip-indexing --skip-cloud-checks` succeeds
- [ ] CI build/lint/test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)