### PR TITLE
Remove SI step

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -625,16 +625,16 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Generate search index with content
-        env:
-          LOCAL_CONTENT_RELATIVE_PATH: ../content
-          TINA_TOKEN: ${{ secrets.TINA_TOKEN }}
-          TINA_SEARCH_TOKEN: ${{ secrets.TINA_SEARCH_TOKEN }}
-          NEXT_PUBLIC_TINA_CLIENT_ID: ${{ inputs.NEXT_PUBLIC_TINA_CLIENT_ID }}
-          NEXT_PUBLIC_TINA_BRANCH: ${{ steps.resolve_content_branch.outputs.content_branch }}
-          NEXT_PUBLIC_GITHUB_ORG: ${{ vars.NEXT_PUBLIC_GITHUB_ORG }}
-          NEXT_PUBLIC_GITHUB_REPO: ${{ vars.NEXT_PUBLIC_GITHUB_REPO }}
-        run: pnpm tinacms search-index
+      # - name: Generate search index with content
+      #   env:
+      #     LOCAL_CONTENT_RELATIVE_PATH: ../content
+      #     TINA_TOKEN: ${{ secrets.TINA_TOKEN }}
+      #     TINA_SEARCH_TOKEN: ${{ secrets.TINA_SEARCH_TOKEN }}
+      #     NEXT_PUBLIC_TINA_CLIENT_ID: ${{ inputs.NEXT_PUBLIC_TINA_CLIENT_ID }}
+      #     NEXT_PUBLIC_TINA_BRANCH: ${{ steps.resolve_content_branch.outputs.content_branch }}
+      #     NEXT_PUBLIC_GITHUB_ORG: ${{ vars.NEXT_PUBLIC_GITHUB_ORG }}
+      #     NEXT_PUBLIC_GITHUB_REPO: ${{ vars.NEXT_PUBLIC_GITHUB_REPO }}
+      #   run: pnpm tinacms search-index
 
       - name: Install Algolia Python dependencies
         run: pip install pyyaml "algoliasearch>=3,<4"


### PR DESCRIPTION
With the introduction of the TinaCloud seperate content repo - a search index no longer needs to be built via CI... it is handled natively by TinaCloud. 