### PR TITLE
Simplify SSW.Rules footer deployment line + iPad portrait fix (+ review follow-ups)

### DIFF
--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -1,8 +1,8 @@
-import moment from "moment";
 import React from "react";
 import { FaFacebook, FaHeart, FaInstagram, FaLinkedin, FaTiktok, FaXTwitter, FaYoutube } from "react-icons/fa6";
 import { GitHubButtonWrapper } from "@/components/GitHubButtonWrapper";
 import { pathPrefix } from "../../../site-config";
+import { RelativeTime } from "./relative-time";
 
 const buildTimestamp = process.env.BUILD_TIMESTAMP ? parseInt(process.env.BUILD_TIMESTAMP) : Date.now() - 1000 * 60 * 30;
 const buildDate = process.env.BUILD_DATE;
@@ -122,9 +122,7 @@ export const Footer = () => {
             <div className="flex flex-col lg:flex-row justify-between mx-6">
               <div className="py-2">
                 This website is under continuous deployment. Last updated{" "}
-                <span title={buildDate ? `Last deployed ${moment(buildDate).format("D MMM YYYY [at] HH:mm UTC")}` : undefined}>
-                  {getLastDeployTime()} ago
-                </span>
+                <RelativeTime buildTimestamp={buildTimestamp} buildDate={buildDate} />
                 {commitHash && (
                   <>
                     . Last commit{" "}
@@ -162,20 +160,4 @@ export const Footer = () => {
       </footer>
     </>
   );
-};
-
-const getLastDeployTime = () => {
-  const lastDeployDuration = moment.duration(Date.now() - buildTimestamp);
-  let delta = Math.abs(lastDeployDuration.asMilliseconds()) / 1000;
-
-  const days = Math.floor(delta / 86400);
-  delta -= days * 86400;
-
-  var hours = Math.floor(delta / 3600) % 24;
-  delta -= hours * 3600;
-
-  var minutes = Math.floor(delta / 60) % 60;
-  delta -= minutes * 60;
-
-  return days !== 0 ? `${days} day(s)` : hours !== 0 ? `${hours} hour(s)` : minutes > 1 ? `${minutes} min` : "1 min";
 };

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -121,15 +121,8 @@ export const Footer = () => {
             <hr className="border-gray-800 my-2"></hr>
             <div className="flex flex-col lg:flex-row justify-between mx-6">
               <div className="py-2">
-                This website is under{" "}
-                <a
-                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
-                  href={`${pathPrefix}/rules-to-better-websites-deployment`}
-                >
-                  continuous deployment
-                </a>
-                . Last updated{" "}
-                <span title={buildDate ? moment(buildDate).format("D MMM YYYY [at] HH:mm UTC") : undefined}>
+                This website is under continuous deployment. Last updated{" "}
+                <span title={buildDate ? `Last deployed ${moment(buildDate).format("D MMM YYYY [at] HH:mm UTC")}` : undefined}>
                   {getLastDeployTime()} ago
                 </span>
                 {commitHash && (
@@ -140,7 +133,6 @@ export const Footer = () => {
                       href={`https://github.com/SSWConsulting/SSW.Rules/commit/${commitHash}`}
                       target="_blank"
                       rel="noopener noreferrer nofollow"
-                      title={`View commit ${commitHash}`}
                     >
                       {commitHash}
                     </a>

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -5,8 +5,6 @@ import { GitHubButtonWrapper } from "@/components/GitHubButtonWrapper";
 import { pathPrefix } from "../../../site-config";
 
 const buildTimestamp = process.env.BUILD_TIMESTAMP ? parseInt(process.env.BUILD_TIMESTAMP) : Date.now() - 1000 * 60 * 30;
-const versionDeployed = process.env.VERSION_DEPLOYED || "dev";
-const deploymentUrl = process.env.DEPLOYMENT_URL || "#";
 const buildDate = process.env.BUILD_DATE;
 const commitHash = process.env.COMMIT_HASH;
 
@@ -35,9 +33,9 @@ export const Footer = () => {
       <footer className="text-center bg-[var(--footer-background)] text-[var(--footer-foreground)] py-6 md:py-4 lg:py-2 [&_a]:no-underline text-xs">
         <section className="main-container max-w-screen-xl">
           <div className="xl:mx-6">
-            <div className="mx-6 flex flex-col-reverse md:flex-row justify-between align-middle leading-6">
+            <div className="mx-6 flex flex-col-reverse lg:flex-row justify-between align-middle leading-6">
               <div className="py-2">&copy; 1990-{new Date().getFullYear()} SSW. All rights reserved.</div>
-              <div className="w-full md:w-3/4 md:text-right py-2 flex max-sm:flex-col items-center max-sm:justify-start justify-center md:justify-end">
+              <div className="w-full lg:w-3/4 lg:text-right py-2 flex max-sm:flex-col items-center max-sm:justify-start justify-center lg:justify-end">
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red max-sm:mb-3"
                   href="https://github.com/SSWConsulting/SSW.Rules/issues"
@@ -121,28 +119,35 @@ export const Footer = () => {
               </div>
             </div>
             <hr className="border-gray-800 my-2"></hr>
-            <div className="flex flex-col md:flex-row justify-between mx-6">
+            <div className="flex flex-col lg:flex-row justify-between mx-6">
               <div className="py-2">
-                ssw.com.au <FaHeart className="text-ssw-red inline" size={12} />{" "}
+                This website is under{" "}
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={`${pathPrefix}/rules-to-better-websites-deployment`}
                 >
-                  CONTINUOUS DEPLOYMENT
+                  continuous deployment
                 </a>
-                . Last deployed {getLastDeployTime()} ago
-                {buildDate && <span title={buildDate}> {moment(buildDate).format("D MMM YYYY [at] HH:mm UTC")}</span>} (Build #{" "}
-                <a
-                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
-                  href={deploymentUrl}
-                  target="_blank"
-                  rel="noopener noreferrer nofollow"
-                >
-                  {versionDeployed}
-                </a>
-                {commitHash && <span title={`Commit: ${commitHash}`}>-{commitHash}</span>})
+                . Last updated{" "}
+                <span title={buildDate ? moment(buildDate).format("D MMM YYYY [at] HH:mm UTC") : undefined}>
+                  {getLastDeployTime()} ago
+                </span>
+                {commitHash && (
+                  <>
+                    . Last commit{" "}
+                    <a
+                      className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
+                      href={`https://github.com/SSWConsulting/SSW.Rules/commit/${commitHash}`}
+                      target="_blank"
+                      rel="noopener noreferrer nofollow"
+                      title={`View commit ${commitHash}`}
+                    >
+                      {commitHash}
+                    </a>
+                  </>
+                )}
               </div>
-              <div className="md:text-right py-2">
+              <div className="lg:text-right py-2">
                 Powered by{" "}
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -124,7 +124,6 @@ export const Footer = () => {
                 This website is under{" "}
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
-                  style={{ textDecoration: "underline" }}
                   href="https://www.ssw.com.au/rules/rules-to-better-websites-deployment"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -123,15 +123,15 @@ export const Footer = () => {
             <hr className="border-gray-800 my-2"></hr>
             <div className="flex flex-col md:flex-row justify-between mx-6">
               <div className="py-2">
-                This website is under{" "}
+                ssw.com.au <FaHeart className="text-ssw-red inline" size={12} />{" "}
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={`${pathPrefix}/rules-to-better-websites-deployment`}
                 >
-                  CONSTANT CONTINUOUS DEPLOYMENT
+                  CONTINUOUS DEPLOYMENT
                 </a>
                 . Last deployed {getLastDeployTime()} ago
-                {buildDate && <span title={buildDate}> on {moment(buildDate).format("MMM D, YYYY [at] HH:mm UTC")}</span>} (Build #{" "}
+                {buildDate && <span title={buildDate}> {moment(buildDate).format("D MMM YYYY [at] HH:mm UTC")}</span>} (Build #{" "}
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href={deploymentUrl}
@@ -180,5 +180,5 @@ const getLastDeployTime = () => {
   var minutes = Math.floor(delta / 60) % 60;
   delta -= minutes * 60;
 
-  return days !== 0 ? `${days} day(s)` : hours !== 0 ? `${hours} hour(s)` : minutes > 1 ? `${minutes} minutes` : "1 minute";
+  return days !== 0 ? `${days} day(s)` : hours !== 0 ? `${hours} hour(s)` : minutes > 1 ? `${minutes} min` : "1 min";
 };

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -4,7 +4,7 @@ import { GitHubButtonWrapper } from "@/components/GitHubButtonWrapper";
 import { pathPrefix } from "../../../site-config";
 import { RelativeTime } from "./relative-time";
 
-const buildTimestamp = process.env.BUILD_TIMESTAMP ? parseInt(process.env.BUILD_TIMESTAMP) : Date.now() - 1000 * 60 * 30;
+const buildTimestamp = process.env.BUILD_TIMESTAMP ? parseInt(process.env.BUILD_TIMESTAMP, 10) : Date.now() - 1000 * 60 * 30;
 const buildDate = process.env.BUILD_DATE;
 const commitHash = process.env.COMMIT_HASH;
 
@@ -126,7 +126,7 @@ export const Footer = () => {
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
                   href="https://www.ssw.com.au/rules/rules-to-better-websites-deployment"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener noreferrer nofollow"
                 >
                   continuous deployment
                 </a>

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -121,7 +121,17 @@ export const Footer = () => {
             <hr className="border-gray-800 my-2"></hr>
             <div className="flex flex-col lg:flex-row justify-between mx-6">
               <div className="py-2">
-                This website is under continuous deployment. Last updated{" "}
+                This website is under{" "}
+                <a
+                  className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
+                  style={{ textDecoration: "underline" }}
+                  href="https://www.ssw.com.au/rules/rules-to-better-websites-deployment"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  continuous deployment
+                </a>
+                . Last updated{" "}
                 <RelativeTime buildTimestamp={buildTimestamp} buildDate={buildDate} />
                 {commitHash && (
                   <>

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -124,9 +124,7 @@ export const Footer = () => {
                 This website is under{" "}
                 <a
                   className="inline-block text-white hover:text-ssw-red visited:text-white leading-3 transition-all duration-300 ease-in-out hover:text-ssw-red"
-                  href="https://www.ssw.com.au/rules/rules-to-better-websites-deployment"
-                  target="_blank"
-                  rel="noopener noreferrer nofollow"
+                  href={`${pathPrefix}/rules-to-better-websites-deployment`}
                 >
                   continuous deployment
                 </a>

--- a/components/layout/nav/relative-time.tsx
+++ b/components/layout/nav/relative-time.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import moment from "moment";
+
+interface Props {
+  buildTimestamp: number;
+  buildDate?: string;
+}
+
+function formatRelative(deltaMs: number): string {
+  const delta = Math.abs(deltaMs) / 1000;
+  const days = Math.floor(delta / 86400);
+  const hours = Math.floor((delta % 86400) / 3600);
+  const minutes = Math.floor((delta % 3600) / 60);
+  if (days > 0) return `${days} day${days > 1 ? "s" : ""} ago`;
+  if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+  if (minutes > 1) return `${minutes} min ago`;
+  return "1 min ago";
+}
+
+/**
+ * Renders "X min/hour/day(s) ago" and ticks every 60s so the relative time
+ * stays accurate even when the page HTML is cached. On hover it shows a
+ * custom tooltip with the exact build date (UTC). Client-only — server
+ * initially renders with delta=0 ("1 min ago") and the client immediately
+ * recomputes on mount to avoid hydration mismatch.
+ */
+export function RelativeTime({ buildTimestamp, buildDate }: Props) {
+  const [now, setNow] = useState<number>(buildTimestamp);
+
+  useEffect(() => {
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const tooltip = buildDate
+    ? `Last deployed ${moment(buildDate).utc().format("D MMM YYYY [at] HH:mm UTC")}`
+    : undefined;
+
+  return (
+    <span className="relative inline-block group cursor-help">
+      {formatRelative(now - buildTimestamp)}
+      {tooltip && (
+        <span
+          role="tooltip"
+          aria-hidden="true"
+          className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 px-2 py-1 bg-white text-gray-900 text-[11px] leading-none rounded whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-md z-10"
+        >
+          {tooltip}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/components/layout/nav/relative-time.tsx
+++ b/components/layout/nav/relative-time.tsx
@@ -40,7 +40,7 @@ export function RelativeTime({ buildTimestamp, buildDate }: Props) {
     : undefined;
 
   return (
-    <span className="relative inline-block group cursor-help">
+    <span className="relative inline-block group cursor-help text-white hover:text-ssw-red transition-all duration-300 ease-in-out">
       {formatRelative(now - buildTimestamp)}
       {tooltip && (
         <span

--- a/components/layout/nav/relative-time.tsx
+++ b/components/layout/nav/relative-time.tsx
@@ -1,12 +1,26 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import moment from "moment";
+import { useEffect, useId, useState } from "react";
 
 interface Props {
   buildTimestamp: number;
   buildDate?: string;
 }
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
 
 function formatRelative(deltaMs: number): string {
   const delta = Math.abs(deltaMs) / 1000;
@@ -19,15 +33,31 @@ function formatRelative(deltaMs: number): string {
   return "1 min ago";
 }
 
+function formatUtcDate(iso: string): string | undefined {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return undefined;
+  const day = d.getUTCDate();
+  const month = MONTHS[d.getUTCMonth()];
+  const year = d.getUTCFullYear();
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${day} ${month} ${year} at ${hh}:${mm} UTC`;
+}
+
 /**
  * Renders "X min/hour/day(s) ago" and ticks every 60s so the relative time
- * stays accurate even when the page HTML is cached. On hover it shows a
- * custom tooltip with the exact build date (UTC). Client-only — server
- * initially renders with delta=0 ("1 min ago") and the client immediately
- * recomputes on mount to avoid hydration mismatch.
+ * stays accurate even when the page HTML is cached. On hover or keyboard
+ * focus it shows a custom tooltip with the exact build date (UTC). Client-
+ * only — server initially renders with delta=0 ("1 min ago") and the
+ * client immediately recomputes on mount to avoid hydration mismatch.
+ *
+ * Accessibility: the wrapper is focusable when a tooltip is present so
+ * keyboard users can reveal it, and the tooltip is linked via
+ * `aria-describedby` so screen readers announce it after the visible time.
  */
 export function RelativeTime({ buildTimestamp, buildDate }: Props) {
   const [now, setNow] = useState<number>(buildTimestamp);
+  const tooltipId = useId();
 
   useEffect(() => {
     setNow(Date.now());
@@ -35,18 +65,21 @@ export function RelativeTime({ buildTimestamp, buildDate }: Props) {
     return () => clearInterval(id);
   }, []);
 
-  const tooltip = buildDate
-    ? `Last deployed ${moment(buildDate).utc().format("D MMM YYYY [at] HH:mm UTC")}`
-    : undefined;
+  const formatted = buildDate ? formatUtcDate(buildDate) : undefined;
+  const tooltip = formatted ? `Last deployed ${formatted}` : undefined;
 
   return (
-    <span className="relative inline-block group cursor-help text-white hover:text-ssw-red transition-all duration-300 ease-in-out">
+    <span
+      className="relative inline-block group cursor-help text-white hover:text-ssw-red focus-visible:text-ssw-red transition-all duration-300 ease-in-out"
+      tabIndex={tooltip ? 0 : undefined}
+      aria-describedby={tooltip ? tooltipId : undefined}
+    >
       {formatRelative(now - buildTimestamp)}
       {tooltip && (
         <span
+          id={tooltipId}
           role="tooltip"
-          aria-hidden="true"
-          className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 px-2 py-1 bg-white text-gray-900 text-[11px] leading-none rounded whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-150 shadow-md z-10"
+          className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1 px-2 py-1 bg-white text-gray-900 text-[11px] leading-none rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 pointer-events-none transition-opacity duration-150 shadow-md z-10"
         >
           {tooltip}
         </span>

--- a/components/layout/nav/relative-time.tsx
+++ b/components/layout/nav/relative-time.tsx
@@ -66,13 +66,14 @@ export function RelativeTime({ buildTimestamp, buildDate }: Props) {
   }, []);
 
   const formatted = buildDate ? formatUtcDate(buildDate) : undefined;
-  const tooltip = formatted ? `Last deployed ${formatted}` : undefined;
+  const tooltip = formatted ? `Last updated ${formatted}` : undefined;
 
   return (
     <span
-      className="relative inline-block group cursor-help text-white hover:text-ssw-red focus-visible:text-ssw-red transition-all duration-300 ease-in-out"
+      className={`relative inline-block group text-white hover:text-ssw-red focus-visible:text-ssw-red transition-all duration-300 ease-in-out${tooltip ? " cursor-help" : ""}`}
       tabIndex={tooltip ? 0 : undefined}
       aria-describedby={tooltip ? tooltipId : undefined}
+      title={tooltip}
     >
       {formatRelative(now - buildTimestamp)}
       {tooltip && (


### PR DESCRIPTION
## Description
✏️ 
- Shortened and modernized the footer deployment line so it fits iPad portrait and narrow widths, including the `md` → `lg` layout breakpoint change.
- Implemented live-updating relative deploy time (`<RelativeTime>`) with a custom UTC tooltip and keyboard-accessible behavior.
- Kept consistent hover affordance across the 3 footer items (white text to red on hover/focus, no underline) and simplified build info to commit hash link.
- Removed Moment usage from this footer surface by using native `Date` formatting.
- Added review follow-up fixes: deployment rule link now uses `pathPrefix` (host-aware for preview/non-prod environments), and relative-time includes a native `title` fallback for broader accessibility support.

## Screenshot (optional)
✏️ 
- Existing PR preview and responsive screenshots remain valid: https://app-sswrules-staging-pr-2646.azurewebsites.net/rules