### PR TITLE
🐛 Fix archived categories not showing archived state

### DIFF
--- a/app/(home)/categories/page.tsx
+++ b/app/(home)/categories/page.tsx
@@ -31,7 +31,7 @@ export default async function CategoriesPage() {
 
   const getTopCategoryTotal = (subCategories: any[]) => subCategories.reduce((total, category) => total + (categoryRuleCounts[category._sys.filename] || 0), 0);
 
-  const isVisibleCategory = (item: any) => item.category && item.category.isArchived !== true && categoryRuleCounts[item.category._sys.filename] > 0;
+  const isVisibleCategory = (item: any) => item.category && !item.category.isArchived && categoryRuleCounts[item.category._sys.filename] > 0;
 
   return (
     <>

--- a/app/(home)/categories/page.tsx
+++ b/app/(home)/categories/page.tsx
@@ -31,27 +31,24 @@ export default async function CategoriesPage() {
 
   const getTopCategoryTotal = (subCategories: any[]) => subCategories.reduce((total, category) => total + (categoryRuleCounts[category._sys.filename] || 0), 0);
 
+  const isVisibleCategory = (item: any) => item.category && item.category.isArchived !== true && categoryRuleCounts[item.category._sys.filename] > 0;
+
   return (
     <>
       <TinaHomepageWrapper tinaHomepageProps={homePageData} ruleCount={ruleCount} latestRules={latestRules}>
         {topCategories
-          .filter(
-            (topCategory) =>
-              topCategory.index &&
-              topCategory.index.length > 0 &&
-              topCategory.index.some((item: any) => item.category && categoryRuleCounts[item.category._sys.filename] > 0)
-          )
+          .filter((topCategory) => topCategory.index && topCategory.index.length > 0 && topCategory.index.some(isVisibleCategory))
           .map((topCategory, index) => (
             <Card key={index} className="mb-4">
               <h2 className="flex justify-between m-0 mb-4 text-2xl max-sm:text-lg">
                 <span>{topCategory.title}</span>
                 <span className="text-gray-500 text-lg">
-                  {getTopCategoryTotal(topCategory.index?.map((item: any) => item.category).filter(Boolean) || [])} Rules
+                  {getTopCategoryTotal(topCategory.index?.filter(isVisibleCategory)?.map((item: any) => item.category) || [])} Rules
                 </span>
               </h2>
               <ol className="text-lg mb-0">
                 {topCategory.index
-                  ?.filter((item: any) => item.category && categoryRuleCounts[item.category._sys.filename] > 0)
+                  ?.filter(isVisibleCategory)
                   ?.map((item: any, subIndex: number) => (
                     <li key={subIndex} className="mb-4 last:mb-2">
                       <div className="flex justify-between">

--- a/app/[filename]/ServerCategoryPage.tsx
+++ b/app/[filename]/ServerCategoryPage.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { tinaField } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import ArchivedReasonContent from "@/components/ArchivedReasonContent";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { CategoryEdit } from "@/components/CategoryEdit";
 import RuleListWrapper from "@/components/rule-list/rule-list-wrapper";
@@ -31,6 +32,28 @@ export default function ServerCategoryPage({ category, path, includeArchived, vi
       <Breadcrumbs isCategory breadcrumbText={includeArchived ? `Archived Rules - ${breadCrumbTitle}` : breadCrumbTitle} />
       <div className="relative">
         <div className="w-full lg:w-2/3 bg-white pt-4 p-6 border border-[#CCC] rounded shadow-lg">
+          {category?.isArchived && category?.archivedreason && (
+            <div className="mb-8 bg-red-50 border border-red-200 rounded-lg p-4">
+              <div className="flex items-start gap-3">
+                <div className="shrink-0">
+                  <svg className="h-5 w-5 text-ssw-red" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path
+                      fillRule="evenodd"
+                      d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-sm font-semibold text-ssw-red m-0 mb-1">This category has been archived</h3>
+                  <div className="text-sm text-ssw-red m-0">
+                    <ArchivedReasonContent reason={category.archivedreason} />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="flex justify-between">
             <h1 className="m-0 mb-4 text-3xl text-ssw-red font-bold">
               {includeArchived ? `Archived Rules - ${title}` : title}

--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -93,6 +93,7 @@ query mainCategoryQuery {
               category {
                 ... on CategoryCategory {
                   title
+                  isArchived
                   _sys {
                     filename
                   }

--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -114,6 +114,8 @@ query categoryWithRulesQuery($relativePath: String!) {
       body
       uri
       seoDescription
+      isArchived
+      archivedreason
       index {
         rule {
           ... on Rule {


### PR DESCRIPTION
### Problem

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2674

Archiving a category in the CMS saves `isArchived` and `archivedreason` to frontmatter, but nothing changes on the site:

- The category page looks the same as a non-archived one (rules show a red warning box, categories don't)
- Archived categories still appear in the /categories list

### Changes

- Fetch `isArchived` and `archivedreason` for the category itself in `categoryWithRulesQuery` (previously only fetched for rules)
- Show a red "This category has been archived" banner on archived category pages, same style as archived rules
- Fetch `isArchived` in `mainCategoryQuery` and hide archived categories from the /categories page (also excluded from rule counts, and a top category with only archived children is hidden entirely)

Archived categories are still accessible by direct URL, showing the banner — same behavior as archived rules.

### Note

8 existing archived categories in SSW.Rules.Content have `archivedreason` but are missing `isArchived: true` — fixed in a separate content PR: https://github.com/SSWConsulting/SSW.Rules.Content/pull/13006


<img width="2084" height="1233" alt="image" src="https://github.com/user-attachments/assets/8db2c6cf-4376-42dc-93f2-ee45d2905975" />
