### PR TITLE
🐛 Show figure prefix when the caption is empty

### DIFF
--- a/components/embeds/figure.tsx
+++ b/components/embeds/figure.tsx
@@ -16,28 +16,36 @@ function renderFigureText(text: string): React.ReactNode {
   });
 }
 
-export function getPrefix(prefix?: FigurePrefix): string {
+function getPrefixLabel(prefix?: FigurePrefix): string {
   switch (prefix) {
     case "bad":
-      return "❌ Figure: Bad example - ";
+      return "❌ Figure: Bad example";
     case "ok":
-      return "🙂 Figure: OK example - ";
+      return "🙂 Figure: OK example";
     case "good":
-      return "✅ Figure: Good example - ";
+      return "✅ Figure: Good example";
     case "none":
     default:
-      return "Figure: ";
+      return "Figure:";
   }
+}
+
+export function getPrefix(prefix?: FigurePrefix, hasText = true): string {
+  const label = getPrefixLabel(prefix);
+  if (!hasText) return label;
+  return prefix === "none" || !prefix ? `${label} ` : `${label} - `;
 }
 
 export function Figure({ prefix = "none", text, className }: { prefix?: FigurePrefix; text?: string; className?: string }) {
   const trimmed = text?.trim();
-  if (!trimmed) return null;
-  const prefixText = getPrefix(prefix);
+  const hasText = Boolean(trimmed);
+  // Nothing to show when there is neither an example type nor caption text
+  if (!hasText && (prefix === "none" || !prefix)) return null;
+  const prefixText = getPrefix(prefix, hasText);
   return (
     <p className={`font-bold mt-1 ${className ?? ""}`.trim()}>
       {prefixText}
-      {renderFigureText(trimmed)}
+      {hasText ? renderFigureText(trimmed as string) : null}
     </p>
   );
 }


### PR DESCRIPTION
Closes #2686

## Problem

The `Figure` component returned `null` whenever the caption was empty. That meant the "Good example" / "Bad example" / "OK example" prefix disappeared too, so editors had to type placeholder text just to make it show up.

## Fix

In `components/embeds/figure.tsx`:

- Split the prefix into a label and a separator. The ` - ` is only added when there is caption text, so no dangling dash is left behind.
- Only return `null` when the type is `none` **and** the caption is empty.

All three embeds (image, email, box) render through this one component, so the fix applies everywhere.

## Result

| Type selected | Caption | Output |
|---|---|---|
| Good | empty | `✅ Figure: Good example` |
| Bad | empty | `❌ Figure: Bad example` |
| OK | empty | `🙂 Figure: OK example` |
| None | empty | nothing |
| Good | `Use DI` | `✅ Figure: Good example - Use DI` (unchanged) |

## Screenshot

<img width="2743" height="1407" alt="image" src="https://github.com/user-attachments/assets/9f2305e3-d7f7-47f2-b228-a1e835a70ee7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UN26ks4fqnnQiGHzXaxL3v